### PR TITLE
Update odocmkgen.ml

### DIFF
--- a/odocmkgen.ml
+++ b/odocmkgen.ml
@@ -42,7 +42,7 @@ module Default = struct
 default: generate
 .PHONY: compile link generate clean html latex man
 compile: odocs
-link: compile Makefile.link odocls
+link: compile odocls
 Makefile.gen : Makefile
 	odocmkgen compile%a%a &> /dev/null
 generate: link


### PR DESCRIPTION
remove `Makefile.link` from `link: compile Makefile.link odocls`. That comes as result of running in an error that kind of pointed to the`link` command in `Makefile`, and having a chat with @jonludlam, he proposed that change.