### PR TITLE
Merge compile and link commands

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,7 @@
-(lang dune 2.5)
+(lang dune 2.7)
 (name odocmkgen)
 (version 0.1)
+(cram enable)
 (generate_opam_files true)
 (package
  (name odocmkgen)

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -1,22 +1,9 @@
 open Listm
 
-(* Returns the relative path to an odoc file based on an input file. For example, given
-   `/home/opam/.opam/4.10.0/lib/ocaml/compiler-libs/lambda.cmi` it will return
-   `odocs/ocaml/compiler-libs/lambda.odoc` *)
-let odoc_dir_of_info info =
-  Fpath.(v "odocs" // info.Inputs.dir )
-
-let odoc_file_of_info info =
-  Fpath.(odoc_dir_of_info info // set_ext "odoc" info.outname)
-  
-  
-
-module StringSet = Set.Make(String)
-
 (* Rules for compiling cm{t,ti,i} files into odoc files *)
 let compile_fragment all_infos info =
   (* Get the filename of the output odoc file *)
-  let odoc_path = odoc_file_of_info info in
+  let odoc_path = Inputs.compile_target info in
 
   let odoc_path_result = Fpath.segs odoc_path |> List.filter (fun x -> x <> "odoc-pages") |> String.concat "/" |> Fpath.of_string in
   let odoc_path = match odoc_path_result with | Ok r -> r | _ -> failwith "error" in
@@ -31,39 +18,20 @@ let compile_fragment all_infos info =
   in
 
   (* Get a list of odoc files for the dependencies *)
-  let dep_odocs = List.map (fun info ->
-    let odoc_file = odoc_file_of_info info in
-    Fpath.to_string odoc_file) deps
-  in
+  let dep_odocs = List.map Inputs.compile_target deps in
 
   (* Odoc requires the directories in which to find the odoc files of the dependencies *)
-  let dep_dirs = Fpath.Set.of_list @@ List.map odoc_dir_of_info deps in
-  let include_str = String.concat " " (Fpath.Set.fold (fun dep_dir acc -> ("-I " ^ Fpath.to_string dep_dir) :: acc ) dep_dirs []) in
+  let include_str =
+    List.map Fpath.(fun p -> to_string (parent p)) dep_odocs
+    |> List.sort_uniq String.compare
+    |> String.concat " "
+  and deps_str = String.concat " " (List.map Fpath.to_string dep_odocs) in
 
-  [ Format.asprintf "%a : %a %s" Fpath.pp odoc_path Fpath.pp Fpath.(info.root // info.dir // info.fname) (String.concat " " dep_odocs);
+  [ Format.asprintf "%a : %a %s" Fpath.pp odoc_path Fpath.pp Fpath.(info.root // info.dir // info.fname) deps_str;
     Format.asprintf "\t@odoc compile --package %s $< %s -o %a" info.package include_str Fpath.pp odoc_path;
     Format.asprintf "compile : %a" Fpath.pp odoc_path;
     Format.asprintf "Makefile.%s.link : %a" info.package Fpath.pp odoc_path ]
 
-(* Rule for generating Makefile.<package>.link *)
-let link_fragment all_infos =
-  let packages = List.map (fun info -> info.Inputs.package) all_infos |> setify in
-  (* For each package, this rule is to generate a Makefile containing the runes to perform the link.
-     It requires all of the package's files to have been compiled first. *)
-  List.map (fun package ->
-      [ Format.asprintf "ifneq ($(MAKECMDGOALS),compile)";
-        Format.asprintf "-include Makefile.%s.link" package;
-        Format.asprintf "endif";
-        Format.asprintf "Makefile.%s.link:" package;
-        Format.asprintf "\t@odocmkgen link --package %s" package ]        
-    ) packages
-
-let run whitelist roots docroots =
-  let inputs = Inputs.find_inputs ~whitelist (roots @ docroots) in
-  let oc = open_out "Makefile.gen" in
-  let lines = List.concat (List.map (compile_fragment inputs) inputs) in
-  List.iter (fun line -> Printf.fprintf oc "%s\n" line) lines;
-  let lines = List.concat (link_fragment inputs) in
-  List.iter (fun line -> Printf.fprintf oc "%s\n" line) lines;
-  close_out oc;
-  ()
+let gen oc inputs =
+  let print_lines = List.iter (Printf.fprintf oc "%s\n") in
+  List.iter (fun inp -> print_lines (compile_fragment inputs inp)) inputs

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -36,7 +36,7 @@ let get_info root mod_file =
      preference *)
   let best_source_file base_path =
     let file_preference = List.map (fun ext -> Fpath.add_ext ext base_path) ["cmti"; "cmt"; "cmi"] in
-    let exists s = try let (_ : Unix.stats) = Unix.stat (Fpath.to_string s) in true with _ -> false in
+    let exists p = Sys.file_exists (Fpath.to_string p) in
     List.find exists file_preference
   in
 

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -1,79 +1,10 @@
 open Listm
 
-(** [odoc_info] represents the necessary information about a particular cmi/cmti/cmt file *)
-type odoc_info = {
-  name : string; (** 'Astring' *)
-
-  root : Fpath.t;   (** Root path in which this was found, e.g. /home/opam/.opam/4.10.0/lib *)
-  dir : Fpath.t;    (** Containing dir path relative to root 'astring/' *)
-  fname : Fpath.t;  (** Filename with extension. The full path is [root]/[dir]/[fname] *)
-  outname : Fpath.t; (** Output filename *)
-
-  digest : Digest.t; (** Digest of the compilation unit itself *)
-  package : string;  (** Package in which this file lives ("astring") *)
-  deps : Odoc.compile_dep list; (** dependencies of this file *)
-}
-
-let pp fmt x =
-  Format.fprintf fmt "@[<v 2>{ name: %s@,root: %a@,dir: %a@,fname: %a@,digest: %s@,package:%s }@]"
-    x.name Fpath.pp x.root Fpath.pp x.dir Fpath.pp x.fname x.digest x.package
-
-
-(* This assumes that the directory immediately below the 'root' is the name of the package.
-   Note that for some older packages this is not always true (e.g. ocamlfind, oasis).
-   Be warned! *)
-let package_of_relpath relpath =
-  match Fpath.segs relpath with
-  | pkg :: _ -> pkg
-  | _ ->
-    Format.eprintf "Invalid path, unable to determine package: %a\n%!" Fpath.pp relpath;
-    failwith "Invalid path"
-
-(* Get info given a base file (cmt, cmti or cmi) *)
-let get_info root mod_file =
-
-  (* Given the choice between a cmti, a cmt and a cmi file, we chose them in that order of
-     preference *)
-  let best_source_file base_path =
-    let file_preference = List.map (fun ext -> Fpath.add_ext ext base_path) ["cmti"; "cmt"; "cmi"] in
-    let exists p = Sys.file_exists (Fpath.to_string p) in
-    List.find exists file_preference
-  in
-
-  let best_file = best_source_file mod_file in
-  let deps = Odoc.compile_deps best_file in
-  let (_, lname) = Fpath.split_base mod_file in
-  let name = String.capitalize_ascii (Fpath.to_string lname) in
-  let relpath = match Fpath.relativize ~root best_file with Some p -> p | None -> failwith "odd" in
-  let (dir, fname) = Fpath.split_base relpath in
-  let outname = Fpath.set_ext "odoc" fname in
-  let package = package_of_relpath relpath in
-  match List.partition (fun d -> d.Odoc.c_unit_name = name) deps with
-  | [self], deps ->
-    let digest = self.c_digest in
-    let result = {root; name; dir; digest; deps; package; fname; outname } in
-    (* Format.eprintf "%a\n%!" pp result; *)
-    [result]
-  | _ ->
-    Format.eprintf "Failed to find digest for self (%s)\n%!" name;
-    []
-
-
-let get_mld_info root mld_file =
-  let file = Fpath.add_ext "mld" mld_file in
-  let (_, lname) = Fpath.split_base mld_file in
-  let name = Format.asprintf "page-%a" Fpath.pp lname in
-  let relpath = match Fpath.relativize ~root file with Some p -> p | None -> failwith "odd" in
-  let (dir, fname) = Fpath.split_base relpath in
-  let package = package_of_relpath relpath in
-  let outname = Fpath.set_ext "odoc" (Fpath.v ("page-" ^ Fpath.to_string fname)) in
-  [{root; name; dir; digest=""; deps=[]; package; fname; outname}]
-
 (* Returns the relative path to an odoc file based on an input file. For example, given
    `/home/opam/.opam/4.10.0/lib/ocaml/compiler-libs/lambda.cmi` it will return
    `odocs/ocaml/compiler-libs/lambda.odoc` *)
 let odoc_dir_of_info info =
-  Fpath.(v "odocs" // info.dir )
+  Fpath.(v "odocs" // info.Inputs.dir )
 
 let odoc_file_of_info info =
   Fpath.(odoc_dir_of_info info // set_ext "odoc" info.outname)
@@ -93,7 +24,7 @@ let compile_fragment all_infos info =
   (* Find by digest the [source_info] for each dependency in our source_info record *)
   let deps =
     info.deps >>= fun dep ->
-    try [ List.find (fun x -> x.digest = dep.Odoc.c_digest) all_infos ]
+    try [ List.find (fun x -> x.Inputs.digest = dep.Odoc.c_digest) all_infos ]
     with Not_found ->
       Format.eprintf "Warning, couldn't find dep %s of file %a\n" dep.Odoc.c_unit_name Fpath.pp (Fpath.(info.dir // info.fname));
       []
@@ -116,7 +47,7 @@ let compile_fragment all_infos info =
 
 (* Rule for generating Makefile.<package>.link *)
 let link_fragment all_infos =
-  let packages = List.map (fun info -> info.package) all_infos |> setify in
+  let packages = List.map (fun info -> info.Inputs.package) all_infos |> setify in
   (* For each package, this rule is to generate a Makefile containing the runes to perform the link.
      It requires all of the package's files to have been compiled first. *)
   List.map (fun package ->
@@ -128,27 +59,11 @@ let link_fragment all_infos =
     ) packages
 
 let run whitelist roots docroots =
-  let infos =
-    roots >>= fun root ->
-    Inputs.find_files ["cmi";"cmt";"cmti"] root
-    >>= get_info root
-  in
-  let infos =
-    if List.length whitelist > 0
-    then List.filter (fun info -> List.mem info.package whitelist) infos
-    else infos
-  in
-  let mlds =
-    docroots >>= fun root ->
-    Inputs.find_files ["mld"] root
-    >>= get_mld_info root
-  in
+  let inputs = Inputs.find_inputs ~whitelist (roots @ docroots) in
   let oc = open_out "Makefile.gen" in
-  let lines = List.concat (List.map (compile_fragment infos) infos) in
+  let lines = List.concat (List.map (compile_fragment inputs) inputs) in
   List.iter (fun line -> Printf.fprintf oc "%s\n" line) lines;
-  let lines = List.concat (List.map (compile_fragment infos) mlds) in
-  List.iter (fun line -> Printf.fprintf oc "%s\n" line) lines;
-  let lines = List.concat (link_fragment infos) in
+  let lines = List.concat (link_fragment inputs) in
   List.iter (fun line -> Printf.fprintf oc "%s\n" line) lines;
   close_out oc;
   ()

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -13,7 +13,7 @@ let compile_fragment all_infos info =
     info.deps >>= fun dep ->
     try [ List.find (fun x -> x.Inputs.digest = dep.Odoc.c_digest) all_infos ]
     with Not_found ->
-      Format.eprintf "Warning, couldn't find dep %s of file %a\n" dep.Odoc.c_unit_name Fpath.pp (Fpath.(info.dir // info.fname));
+      Format.eprintf "Warning, couldn't find dep %s of file %a\n" dep.Odoc.c_unit_name Fpath.pp info.relpath;
       []
   in
 
@@ -27,7 +27,7 @@ let compile_fragment all_infos info =
     |> String.concat " "
   and deps_str = String.concat " " (List.map Fpath.to_string dep_odocs) in
 
-  [ Format.asprintf "%a : %a %s" Fpath.pp odoc_path Fpath.pp Fpath.(info.root // info.dir // info.fname) deps_str;
+  [ Format.asprintf "%a : %a %s" Fpath.pp odoc_path Fpath.pp (Inputs.input_file info) deps_str;
     Format.asprintf "\t@odoc compile --package %s $< %s -o %a" info.package include_str Fpath.pp odoc_path;
     Format.asprintf "compile : %a" Fpath.pp odoc_path;
     Format.asprintf "Makefile.%s.link : %a" info.package Fpath.pp odoc_path ]

--- a/lib/gen.ml
+++ b/lib/gen.ml
@@ -1,0 +1,8 @@
+let run whitelist roots docroots =
+  let inputs = Inputs.find_inputs ~whitelist (roots @ docroots) in
+  let oc = open_out "Makefile.gen" in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () ->
+      Compile.gen oc inputs;
+      Link.gen oc inputs)

--- a/lib/generate.ml
+++ b/lib/generate.ml
@@ -12,7 +12,10 @@ let paths_of_package all_files package =
 let run path package =
   let package_makefile = Printf.sprintf "Makefile.%s.generate" package in
 
-  let all_files = Inputs.find_files ["odocl"] path in
+  let all_files = Inputs.find_files path >>= fun p ->
+    let base, ext = Fpath.split_ext p in
+    if ext = ".odocl" then [ base ] else []
+  in
 
   let pkg_files = paths_of_package all_files package in
 

--- a/lib/inputs.ml
+++ b/lib/inputs.ml
@@ -1,27 +1,13 @@
 open Listm
 
-let with_open_dir d f =
-  let dh = Unix.opendir (Fpath.to_string d) in
-  Fun.protect
-    ~finally:(fun () -> Unix.closedir dh)
-    (fun () ->
-      f dh)
-
-let filter_dots = function
-| "." -> []
-| ".." -> []
-| e -> [e]
-  
 let contents dir =
-  with_open_dir dir (fun dh ->
-    let rec loop acc =
-      try loop (Unix.readdir dh :: acc) with _ -> acc
-    in loop []) >>= filter_dots >>= fun x -> [Fpath.(dir / x)]
+  Sys.readdir (Fpath.to_string dir)
+  |> Array.map (Fpath.( / ) dir)
+  |> Array.to_list
 
 let filter pred item = if pred item then [item] else []
 
-let is_dir x =
-  try Unix.((stat (Fpath.to_string x)).st_kind = S_DIR) with _ -> false
+let is_dir x = Sys.is_directory (Fpath.to_string x)
 
 let has_ext exts f =
   List.exists (fun suffix -> Fpath.has_ext suffix f) exts

--- a/lib/inputs.ml
+++ b/lib/inputs.ml
@@ -12,9 +12,112 @@ let is_dir x = Sys.is_directory (Fpath.to_string x)
 let has_ext exts f =
   List.exists (fun suffix -> Fpath.has_ext suffix f) exts
 
-let rec find_files extensions base_dir =
+let rec find_files base_dir =
   let items = contents base_dir in
-  let dirs = items >>= filter is_dir in
-  let cmis = items >>= filter (has_ext extensions) |> List.map Fpath.rem_ext |> setify in
-  let subitems = dirs >>= find_files extensions in
-  cmis @ subitems
+  let dirs, files = List.partition is_dir items in
+  let subitems = dirs >>= find_files in
+  files @ subitems
+
+(** Lower is better *)
+let cm_file_preference = function
+  | ".cmti" -> Some 1
+  | ".cmt" -> Some 2
+  | ".cmi" -> Some 3
+  | _ -> None
+
+(** Get cm* files out of a list of files.
+    Given the choice between a cmti, a cmt and a cmi file, we chose them according to [cm_file_preference] above *)
+let get_cm_files files =
+  let rec skip f = function hd :: tl when f hd -> skip f tl | x -> x in
+  (* Take the first of each group. *)
+  let rec dedup acc = function
+    | (base, _, p) :: tl ->
+        let tl = skip (fun (base', _, _) -> base = base') tl in
+        dedup (p :: acc) tl
+    | [] -> acc
+  in
+  (* Sort files by their basename and preference, remove other files *)
+  files
+  >>= (fun p ->
+        let without_ext, ext = Fpath.split_ext p in
+        match cm_file_preference ext with
+        | Some pref -> [ (Fpath.basename without_ext, pref, p) ]
+        | None -> [])
+  |> List.sort compare |> dedup []
+
+(** Get mld files out of a list of files. *)
+let get_mld_files = List.filter (Fpath.has_ext ".mld")
+
+(* This assumes that the directory immediately below the 'root' is the name of the package.
+   Note that for some older packages this is not always true (e.g. ocamlfind, oasis).
+   Be warned! *)
+let package_of_relpath relpath =
+  match Fpath.segs relpath with
+  | pkg :: _ -> pkg
+  | _ ->
+    Format.eprintf "Invalid path, unable to determine package: %a\n%!" Fpath.pp relpath;
+    failwith "Invalid path"
+
+(** Represents the necessary information about a particular compilation unit *)
+type t = {
+  name : string; (** 'Astring' *)
+
+  root : Fpath.t;   (** Root path in which this was found, e.g. /home/opam/.opam/4.10.0/lib *)
+  dir : Fpath.t;    (** Containing dir path relative to root 'astring/' *)
+  fname : Fpath.t;  (** Filename with extension. The full path is [root]/[dir]/[fname] *)
+  outname : Fpath.t; (** Output filename *)
+
+  digest : Digest.t; (** Digest of the compilation unit itself *)
+  package : string;  (** Package in which this file lives ("astring") *)
+  deps : Odoc.compile_dep list; (** dependencies of this file *)
+}
+
+let pp fmt x =
+  Format.fprintf fmt "@[<v 2>{ name: %s@,root: %a@,dir: %a@,fname: %a@,digest: %s@,package:%s }@]"
+    x.name Fpath.pp x.root Fpath.pp x.dir Fpath.pp x.fname x.digest x.package
+
+(* Get info given a base file (cmt, cmti or cmi) *)
+let get_cm_info root file =
+  let deps = Odoc.compile_deps file in
+  let relpath =
+    match Fpath.relativize ~root file with
+    | Some p -> p
+    | None -> failwith "odd"
+  in
+  let dir, fname = Fpath.split_base relpath in
+  let name = String.capitalize_ascii Fpath.(to_string (rem_ext fname)) in
+  let outname = Fpath.set_ext "odoc" fname in
+  let package = package_of_relpath relpath in
+  match List.partition (fun d -> d.Odoc.c_unit_name = name) deps with
+  | [ self ], deps ->
+      let digest = self.c_digest in
+      let result = { root; name; dir; digest; deps; package; fname; outname } in
+      (* Format.eprintf "%a\n%!" pp result; *)
+      [ result ]
+  | _ ->
+      Format.eprintf "Failed to find digest for self (%s)\n%!" name;
+      []
+
+let get_mld_info root file =
+  let relpath =
+    match Fpath.relativize ~root file with
+    | Some p -> p
+    | None -> failwith "odd"
+  in
+  let dir, fname = Fpath.split_base relpath in
+  let name = Format.asprintf "page-%a" Fpath.pp (Fpath.rem_ext fname) in
+  let package = package_of_relpath relpath in
+  let outname = Fpath.add_ext "odoc" (Fpath.v name) in
+  [ { root; name; dir; digest = ""; deps = []; package; fname; outname } ]
+
+let find_inputs ~whitelist roots =
+  let roots = List.sort_uniq Fpath.compare roots in
+  let infos =
+    roots >>= fun root ->
+    let files = find_files root in
+    (get_cm_files files >>= get_cm_info root)
+    @ (get_mld_files files >>= get_mld_info root)
+  in
+  if List.length whitelist > 0 then
+    List.filter (fun info -> List.mem info.package whitelist) infos
+  else infos

--- a/lib/link.ml
+++ b/lib/link.ml
@@ -42,7 +42,10 @@ let paths_of_package all_files package =
    the following function somewhat. *)
 let run toppath package =
     (* Find all odoc files, result is list of Fpath.t with no extension *)
-    let all_files = Inputs.find_files ["odoc"] toppath in
+    let all_files = Inputs.find_files toppath >>= fun p ->
+      let base, ext = Fpath.split_ext p in
+      if ext = ".odoc" then [ base ] else []
+    in
 
     let pkg_files = filter_by_package all_files package in 
 

--- a/lib/link.ml
+++ b/lib/link.ml
@@ -1,99 +1,70 @@
-(* Generate the Makefile.<package>.link files *)
+(** Generate linking rules *)
 
 open Listm
 
-let is_hidden x =
-  let is_hidden s =
-    let len = String.length s in
-    let rec aux i =
-        if i > len - 2 then false else
-        if s.[i] = '_' && s.[i + 1] = '_' then true
-        else aux (i + 1)
-    in aux 0
+module StringMap = Map.Make (String)
+
+let is_hidden s =
+  let len = String.length s in
+  let rec aux i =
+      if i > len - 2 then false else
+      if s.[i] = '_' && s.[i + 1] = '_' then true
+      else aux (i + 1)
+  in aux 0
+
+let split_packages inputs =
+  let f inp = function Some lst -> Some (inp :: lst) | None -> Some [ inp ] in
+  List.fold_left
+    (fun acc inp -> StringMap.update inp.Inputs.package (f inp) acc)
+    StringMap.empty inputs
+  |> StringMap.bindings
+
+let gen_input oc ~inputs_map inp =
+  let deps =
+    let find_input d = StringMap.find_opt d.Odoc.c_unit_name inputs_map in
+    List.filter_map find_input inp.Inputs.deps
   in
-  is_hidden (Fpath.basename x)
-
-let filter_by_package all_files package =
-  List.filter (fun file ->
-    match Fpath.(segs (normalize file)) with
-    | "odocs" :: pkg :: _ when pkg = package -> true
-    | _ -> false) all_files
-
-let get_dir f = fst (Fpath.split_base f)
-  
-let paths_of_package all_files package =
-  let package_files = filter_by_package all_files package in
-  let dirs = List.map get_dir package_files in
-  setify dirs
-
+  let deps_odoc = List.map Inputs.compile_target deps in
+  let deps_dirs =
+    List.map (fun p -> Fpath.(to_string (parent p))) deps_odoc
+    |> List.sort_uniq String.compare
+  and deps_odoc = List.map Fpath.to_string deps_odoc in
+  let input_file = Fpath.(to_string (Inputs.compile_target inp))
+  and output_file = Fpath.(to_string (Inputs.link_target inp)) in
+  let deps_inc = List.map (( ^ ) "-I ") deps_dirs in
+  Printf.fprintf oc "%s : %s %s\n\t@odoc link $< -o $@ %s\nlink: %s\n"
+    output_file input_file
+    (String.concat " " deps_odoc)
+    (String.concat " " deps_inc)
+    output_file
 
 (* Ideally we would have a list of packages on which the specified package depends.
-   Given that, it's a simple case of calling `odoc link` on each non-hidden odoc file
-   with the include paths set to point to the directories containing the odoc files
-   of the dependencies.
-   
    Here we're making an assumption - that the references in the doc comments will
    only be referring to packages that are required to compile the modules. Other
    drivers may be able to supply additional packages in which to find referenced
    elements.
-   
-   We're actually finding out what packages are required by calling `odoc link-deps`,
-   which will give us enough packages to resolve all of the paths. This complicates
-   the following function somewhat. *)
-let run toppath package =
-    (* Find all odoc files, result is list of Fpath.t with no extension *)
-    let all_files = Inputs.find_files toppath >>= fun p ->
-      let base, ext = Fpath.split_ext p in
-      if ext = ".odoc" then [ base ] else []
-    in
 
-    let pkg_files = filter_by_package all_files package in 
-
-    (* get rid of hidden files *)
-    let files = pkg_files >>= filter (fun f -> not (is_hidden f)) in
-
-    (* Find the set of directories that contain all of the files *)
-    let dirs = Fpath.Set.of_list (List.map (fun f -> fst (Fpath.split_base f)) pkg_files) in
-
-    (* For each directory, use odoc to find the union of the set of packages each odoc file requires *)
-    let odoc_deps = Fpath.Set.fold (fun dir acc -> Fpath.Map.add dir (Odoc.link_deps dir) acc) dirs Fpath.Map.empty in
-
-    let package_makefile = Printf.sprintf "Makefile.%s.link" package in
-
-    let oc = open_out package_makefile in
-    let fmt = Format.formatter_of_out_channel oc in
-
-    let output_files = List.map (fun file ->
-      (* The directory containing the odoc file *)
-      let dir = fst (Fpath.split_base file) in
-
-      (* Find the corresponding entry in the map of package dependencies odoc has calculated *)
-      let deps = Option.get @@ Fpath.Map.find dir odoc_deps in
-
-      (* Extract the packages and remove duplicates *)
-      let dep_packages = setify @@ List.map (fun dep -> dep.Odoc.l_package) deps in
-
-      (* Find the directories that contain these packages - note the mapping of package -> 
-         directory is one-to-many *)
-      let dirs = setify @@ dep_packages >>= fun package -> paths_of_package all_files package in
-      
-      let output_file = match Fpath.segs file with
-        | "odocs" :: rest -> Fpath.(v (String.concat dir_sep ("odocls" :: rest)))
-        | path :: _ -> Format.eprintf "odoc file unexpectedly found in path %s\n%!" path;
-          exit 1
-        | _ -> Format.eprintf "Something odd happening with the odoc paths\n%!";
-          exit 1
-      in
-
-      List.iter (fun package ->
-        Format.fprintf fmt "%a.odocl : Makefile.%s.link\n%!" Fpath.pp output_file package) dep_packages;
-      Format.fprintf fmt "%a.odocl : %a.odoc\n\t@odoc link %a.odoc -o %a.odocl %s\nlink: %a.odocl\n%!"
-        Fpath.pp output_file Fpath.pp file Fpath.pp file Fpath.pp output_file
-        (String.concat " " (List.map (fun dir -> Format.asprintf "-I %a" Fpath.pp dir) dirs))
-        Fpath.pp output_file;
-        output_file
-      ) files in
-    Printf.fprintf oc "Makefile.%s.generate: %s\n\todocmkgen generate --package %s\n" package (String.concat " " (List.map (fun f -> Fpath.(to_string (add_ext "odocl" f))) output_files)) package;
-    Printf.fprintf oc "-include Makefile.%s.generate\n" package;
-    close_out oc
-    
+   We assume that link dependencies are the same as the corresponding compile
+   dependencies. *)
+let gen oc (inputs : Inputs.t list) =
+  let inputs_map =
+    StringMap.of_seq
+      (Seq.map (fun inp -> (inp.Inputs.name, inp)) (List.to_seq inputs))
+  in
+  (* Don't link hidden modules *)
+  let link_inputs =
+    inputs >>= filter (fun inp -> not (is_hidden inp.Inputs.name))
+  in
+  List.iter (gen_input oc ~inputs_map) link_inputs;
+  (* Call generate Makefiles *)
+  split_packages inputs
+  |> List.iter (fun (package, inputs) ->
+         let output_files =
+           List.map (fun inp -> Fpath.to_string (Inputs.link_target inp)) inputs
+         in
+         Printf.fprintf oc
+           "Makefile.%s.generate: %s\n\todocmkgen generate --package %s\n"
+           package
+           (String.concat " " output_files)
+           package;
+         Printf.fprintf oc "-include Makefile.%s.generate\n" package)

--- a/lib/odoc.ml
+++ b/lib/odoc.ml
@@ -7,13 +7,6 @@ type compile_dep = {
   c_unit_name : string;
   c_digest : Digest.t;
 }
-    
-type link_dep = {
-  l_package : string;
-  l_name : string;
-  l_digest : Digest.t;
-}
-
 
 (* *)
 let compile_deps file =
@@ -24,16 +17,6 @@ let compile_deps file =
     | _ -> []
   in
   Util.lines_of_process (Format.asprintf "odoc compile-deps %a" Fpath.pp file)
-  >>= process_line
-
-let link_deps dir =
-  let process_line line =
-    match Astring.String.cuts ~sep:" " line with
-    | [l_package; l_name; l_digest] ->
-      [{l_package; l_name; l_digest}]
-    | _ -> []
-  in
-  Util.lines_of_process (Format.asprintf "odoc link-deps %a" Fpath.pp dir)
   >>= process_line
 
 let generate_targets odocl ty =

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1,15 +1,18 @@
 (* util.ml *)
 
 let lines_of_process p =
-    let ic = Unix.open_process_in p in
-    let lines = Fun.protect
-      ~finally:(fun () -> ignore(Unix.close_process_in ic))
-      (fun () ->
-        let rec inner acc =
-          try
-            let l = input_line ic in
-            inner (l::acc)
-          with End_of_file -> List.rev acc
-        in inner [])
+  let ic = Unix.open_process_in p in
+  let lines =
+    let rec inner acc =
+      try
+        let l = input_line ic in
+        inner (l :: acc)
+      with End_of_file -> List.rev acc
     in
-    lines
+    inner []
+  in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> lines
+  | _ ->
+      Format.eprintf "Command failed: %s\n" p;
+      exit 1

--- a/odocmkgen.ml
+++ b/odocmkgen.ml
@@ -54,7 +54,7 @@ default: generate
 compile: odocs
 link: compile odocls
 Makefile.gen : Makefile
-	odocmkgen compile%a%a%a
+	odocmkgen gen%a%a%a
 generate: link
 odocs:
 	mkdir odocs
@@ -95,10 +95,7 @@ endif
     Term.info ~version:"%%VERSION%%" "odocmkgen"
 end
 
-module Compile = struct
-
-  let compile whitelist lib_dir doc_dir =
-    Compile.run whitelist lib_dir doc_dir
+module Gen = struct
 
   let whitelist =
     Arg.(value & opt (list string) [] & info ["w"; "whitelist"])
@@ -120,24 +117,10 @@ module Compile = struct
     (* [some string] and not [some dir] because we don't need it to exist yet. *)
     Arg.(value & opt_all (fpath_dir) [] & info ["D"] ~doc ~docv:"DOC_DIR")
 
-  let cmd = Term.(const compile $ whitelist $ lib_dir $ doc_dir)
+  let cmd = Term.(const Gen.run $ whitelist $ lib_dir $ doc_dir)
 
-  let info = Term.info "compile" ~doc:"Produce a makefile for compiling odoc files"
-end
+  let info = Term.info "gen" ~doc:"Produce a makefile for building the documentation."
 
-module Link = struct
-  let link package =
-    Link.run (Fpath.v "odocs") package
-
-  let package =
-    let doc = "Select the package to examine" in
-    Arg.(required & opt (some string) None & info ["p"; "package"]
-            ~docv:"PKG" ~doc)
-    
-  let cmd = Term.(const link $ package)
-
-  let info = Term.info "link" ~doc:"Produce a makefile for linking odoc files"
-  
 end
 
 module Generate = struct
@@ -173,10 +156,8 @@ module OpamDeps = struct
 end
 
 let _ =
-  match Term.eval_choice ~err:Format.err_formatter Default.(cmd,info) [Compile.(cmd, info); Link.(cmd, info); Generate.(cmd, info); OpamDeps.(cmd, info)] with
+  match Term.eval_choice ~err:Format.err_formatter Default.(cmd,info) [Gen.(cmd, info); Generate.(cmd, info); OpamDeps.(cmd, info)] with
   | `Error _ ->
     Format.pp_print_flush Format.err_formatter ();
     exit 2
   | _ -> ()
-
-

--- a/odocmkgen.ml
+++ b/odocmkgen.ml
@@ -16,11 +16,11 @@ let conv_compose ?docv parse to_string c =
 
 (* Just to find the location of all relevant ocaml cmt/cmti/cmis *)
 let read_lib_dir () =
-  let ic = Unix.open_process_in "ocamlfind printconf path" in
-  let base_dir = input_line ic in
-  match Unix.close_process_in ic with
-  | Unix.WEXITED 0 -> base_dir
-  | _ -> Format.eprintf "Failed to find ocaml lib path"; exit 1
+  match Util.lines_of_process "ocamlfind printconf path" with
+  | [ base_dir ] -> base_dir
+  | _ ->
+      Format.eprintf "Failed to find ocaml lib path";
+      exit 1
 
 let read_doc_dir () =
   let dir = read_lib_dir () in

--- a/odocmkgen.opam
+++ b/odocmkgen.opam
@@ -2,10 +2,11 @@
 opam-version: "2.0"
 version: "0.1"
 depends: [
-  "dune" {>= "2.5"}
+  "dune" {>= "2.7"}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps %{bin:odocmkgen} %{bin:odoc}))

--- a/test/example.t/a/a.ml
+++ b/test/example.t/a/a.ml
@@ -1,0 +1,1 @@
+let hello_world = B.hello ^ " world"

--- a/test/example.t/a/a.mli
+++ b/test/example.t/a/a.mli
@@ -1,0 +1,2 @@
+(** On top of {!B.hello} *)
+val hello_world : string

--- a/test/example.t/b/b.ml
+++ b/test/example.t/b/b.ml
@@ -1,0 +1,1 @@
+let hello = "Hello"

--- a/test/example.t/b/b.mli
+++ b/test/example.t/b/b.mli
@@ -1,0 +1,1 @@
+val hello : string

--- a/test/example.t/run.t
+++ b/test/example.t/run.t
@@ -6,17 +6,17 @@ The driver works on compiled files:
 
   $ make html
   odocmkgen compile -L . -D .
-  Warning, couldn't find dep CamlinternalFormatBasics of file a/a.cmi
-  Warning, couldn't find dep Stdlib of file a/a.cmi
   Warning, couldn't find dep CamlinternalFormatBasics of file b/b.cmi
   Warning, couldn't find dep Stdlib of file b/b.cmi
-  Starting link
-  odocmkgen generate --package b
+  Warning, couldn't find dep CamlinternalFormatBasics of file a/a.cmi
+  Warning, couldn't find dep Stdlib of file a/a.cmi
   Starting link
   odocmkgen generate --package a
+  Starting link
+  odocmkgen generate --package b
   odoc support-files --output-dir html
-  odoc html-generate odocls/a/a.odocl --output-dir html
   odoc html-generate odocls/b/b.odocl --output-dir html
+  odoc html-generate odocls/a/a.odocl --output-dir html
 
   $ find
   .
@@ -57,3 +57,73 @@ The driver works on compiled files:
   ./odocs/b/b.odoc
   ./odocs/a
   ./odocs/a/a.odoc
+
+  $ cat Makefile*
+  
+  default: generate
+  .PHONY: compile link generate clean html latex man
+  compile: odocs
+  link: compile odocls
+  Makefile.gen : Makefile
+  	odocmkgen compile -L . -D .
+  generate: link
+  odocs:
+  	mkdir odocs
+  odocls:
+  	mkdir odocls
+  clean:
+  	rm -rf odocs odocls html latex man Makefile.*link Makefile.gen Makefile.*generate
+  html: html/odoc.css
+  html/odoc.css:
+  	odoc support-files --output-dir html
+  ifneq ($(MAKECMDGOALS),clean)
+  -include Makefile.gen
+  endif
+  html/a/A/index.html &: odocls/a/a.odocl
+  	odoc html-generate odocls/a/a.odocl --output-dir html
+  html : html/a/A/index.html
+  latex/a/A.tex &: odocls/a/a.odocl
+  	odoc latex-generate odocls/a/a.odocl --output-dir latex
+  latex : latex/a/A.tex
+  man/a/A.3o &: odocls/a/a.odocl
+  	odoc man-generate odocls/a/a.odocl --output-dir man
+  man : man/a/A.3o
+  odocls/a/a.odocl : odocs/a/a.odoc
+  	@odoc link odocs/a/a.odoc -o odocls/a/a.odocl 
+  link: odocls/a/a.odocl
+  Makefile.a.generate: odocls/a/a.odocl
+  	odocmkgen generate --package a
+  -include Makefile.a.generate
+  html/b/B/index.html &: odocls/b/b.odocl
+  	odoc html-generate odocls/b/b.odocl --output-dir html
+  html : html/b/B/index.html
+  latex/b/B.tex &: odocls/b/b.odocl
+  	odoc latex-generate odocls/b/b.odocl --output-dir latex
+  latex : latex/b/B.tex
+  man/b/B.3o &: odocls/b/b.odocl
+  	odoc man-generate odocls/b/b.odocl --output-dir man
+  man : man/b/B.3o
+  odocls/b/b.odocl : odocs/b/b.odoc
+  	@odoc link odocs/b/b.odoc -o odocls/b/b.odocl 
+  link: odocls/b/b.odocl
+  Makefile.b.generate: odocls/b/b.odocl
+  	odocmkgen generate --package b
+  -include Makefile.b.generate
+  odocs/b/b.odoc : ./b/b.cmi 
+  	@odoc compile --package b $<  -o odocs/b/b.odoc
+  compile : odocs/b/b.odoc
+  Makefile.b.link : odocs/b/b.odoc
+  odocs/a/a.odoc : ./a/a.cmi 
+  	@odoc compile --package a $<  -o odocs/a/a.odoc
+  compile : odocs/a/a.odoc
+  Makefile.a.link : odocs/a/a.odoc
+  ifneq ($(MAKECMDGOALS),compile)
+  -include Makefile.b.link
+  endif
+  Makefile.b.link:
+  	@odocmkgen link --package b
+  ifneq ($(MAKECMDGOALS),compile)
+  -include Makefile.a.link
+  endif
+  Makefile.a.link:
+  	@odocmkgen link --package a

--- a/test/example.t/run.t
+++ b/test/example.t/run.t
@@ -5,125 +5,21 @@ The driver works on compiled files:
   $ odocmkgen -L . -D . > Makefile
 
   $ make html
-  odocmkgen compile -L . -D .
+  odocmkgen gen -L . -D .
   Warning, couldn't find dep CamlinternalFormatBasics of file b/b.cmi
   Warning, couldn't find dep Stdlib of file b/b.cmi
   Warning, couldn't find dep CamlinternalFormatBasics of file a/a.cmi
   Warning, couldn't find dep Stdlib of file a/a.cmi
   Starting link
-  odocmkgen generate --package a
-  Starting link
   odocmkgen generate --package b
+  Starting link
+  odocmkgen generate --package a
   odoc support-files --output-dir html
-  odoc html-generate odocls/b/b.odocl --output-dir html
   odoc html-generate odocls/a/a.odocl --output-dir html
+  odoc html-generate odocls/b/b.odocl --output-dir html
 
-  $ find
-  .
-  ./odocls
-  ./odocls/b
-  ./odocls/b/b.odocl
-  ./odocls/a
-  ./odocls/a/a.odocl
-  ./b
-  ./b/b.mli
-  ./b/b.cmo
-  ./b/b.ml
-  ./b/b.cmi
-  ./Makefile.b.link
-  ./Makefile.gen
-  ./html
-  ./html/b
-  ./html/b/B
-  ./html/b/B/index.html
-  ./html/odoc.css
-  ./html/highlight.pack.js
-  ./html/a
-  ./html/a/A
-  ./html/a/A/index.html
-  ./Makefile
-  ./Makefile.b.generate
-  ./Makefile.a.generate
-  ./run.t
-  ./a.out
-  ./Makefile.a.link
-  ./a
-  ./a/a.ml
-  ./a/a.mli
-  ./a/a.cmo
-  ./a/a.cmi
-  ./odocs
-  ./odocs/b
-  ./odocs/b/b.odoc
-  ./odocs/a
-  ./odocs/a/a.odoc
-
-  $ cat Makefile*
-  
-  default: generate
-  .PHONY: compile link generate clean html latex man
-  compile: odocs
-  link: compile odocls
-  Makefile.gen : Makefile
-  	odocmkgen compile -L . -D .
-  generate: link
-  odocs:
-  	mkdir odocs
-  odocls:
-  	mkdir odocls
-  clean:
-  	rm -rf odocs odocls html latex man Makefile.*link Makefile.gen Makefile.*generate
-  html: html/odoc.css
-  html/odoc.css:
-  	odoc support-files --output-dir html
-  ifneq ($(MAKECMDGOALS),clean)
-  -include Makefile.gen
-  endif
-  html/a/A/index.html &: odocls/a/a.odocl
-  	odoc html-generate odocls/a/a.odocl --output-dir html
-  html : html/a/A/index.html
-  latex/a/A.tex &: odocls/a/a.odocl
-  	odoc latex-generate odocls/a/a.odocl --output-dir latex
-  latex : latex/a/A.tex
-  man/a/A.3o &: odocls/a/a.odocl
-  	odoc man-generate odocls/a/a.odocl --output-dir man
-  man : man/a/A.3o
-  odocls/a/a.odocl : odocs/a/a.odoc
-  	@odoc link odocs/a/a.odoc -o odocls/a/a.odocl 
-  link: odocls/a/a.odocl
-  Makefile.a.generate: odocls/a/a.odocl
-  	odocmkgen generate --package a
-  -include Makefile.a.generate
-  html/b/B/index.html &: odocls/b/b.odocl
-  	odoc html-generate odocls/b/b.odocl --output-dir html
-  html : html/b/B/index.html
-  latex/b/B.tex &: odocls/b/b.odocl
-  	odoc latex-generate odocls/b/b.odocl --output-dir latex
-  latex : latex/b/B.tex
-  man/b/B.3o &: odocls/b/b.odocl
-  	odoc man-generate odocls/b/b.odocl --output-dir man
-  man : man/b/B.3o
-  odocls/b/b.odocl : odocs/b/b.odoc
-  	@odoc link odocs/b/b.odoc -o odocls/b/b.odocl 
-  link: odocls/b/b.odocl
-  Makefile.b.generate: odocls/b/b.odocl
-  	odocmkgen generate --package b
-  -include Makefile.b.generate
-  odocs/b/b.odoc : ./b/b.cmi 
-  	@odoc compile --package b $<  -o odocs/b/b.odoc
-  compile : odocs/b/b.odoc
-  Makefile.b.link : odocs/b/b.odoc
-  odocs/a/a.odoc : ./a/a.cmi 
-  	@odoc compile --package a $<  -o odocs/a/a.odoc
-  compile : odocs/a/a.odoc
-  Makefile.a.link : odocs/a/a.odoc
-  ifneq ($(MAKECMDGOALS),compile)
-  -include Makefile.b.link
-  endif
-  Makefile.b.link:
-  	@odocmkgen link --package b
-  ifneq ($(MAKECMDGOALS),compile)
-  -include Makefile.a.link
-  endif
-  Makefile.a.link:
-  	@odocmkgen link --package a
+  $ ls Makefile*
+  Makefile
+  Makefile.a.generate
+  Makefile.b.generate
+  Makefile.gen

--- a/test/example.t/run.t
+++ b/test/example.t/run.t
@@ -1,0 +1,59 @@
+The driver works on compiled files:
+
+  $ ocamlc -I b -I a b/b.mli b/b.ml a/a.mli a/a.ml
+
+  $ odocmkgen -L . -D . > Makefile
+
+  $ make html
+  odocmkgen compile -L . -D .
+  Warning, couldn't find dep CamlinternalFormatBasics of file a/a.cmi
+  Warning, couldn't find dep Stdlib of file a/a.cmi
+  Warning, couldn't find dep CamlinternalFormatBasics of file b/b.cmi
+  Warning, couldn't find dep Stdlib of file b/b.cmi
+  Starting link
+  odocmkgen generate --package b
+  Starting link
+  odocmkgen generate --package a
+  odoc support-files --output-dir html
+  odoc html-generate odocls/a/a.odocl --output-dir html
+  odoc html-generate odocls/b/b.odocl --output-dir html
+
+  $ find
+  .
+  ./odocls
+  ./odocls/b
+  ./odocls/b/b.odocl
+  ./odocls/a
+  ./odocls/a/a.odocl
+  ./b
+  ./b/b.mli
+  ./b/b.cmo
+  ./b/b.ml
+  ./b/b.cmi
+  ./Makefile.b.link
+  ./Makefile.gen
+  ./html
+  ./html/b
+  ./html/b/B
+  ./html/b/B/index.html
+  ./html/odoc.css
+  ./html/highlight.pack.js
+  ./html/a
+  ./html/a/A
+  ./html/a/A/index.html
+  ./Makefile
+  ./Makefile.b.generate
+  ./Makefile.a.generate
+  ./run.t
+  ./a.out
+  ./Makefile.a.link
+  ./a
+  ./a/a.ml
+  ./a/a.mli
+  ./a/a.cmo
+  ./a/a.cmi
+  ./odocs
+  ./odocs/b
+  ./odocs/b/b.odoc
+  ./odocs/a
+  ./odocs/a/a.odoc


### PR DESCRIPTION
This PR merges the `compile` and `link` commands into a confusingly named `gen` command.
The goal was to no longer use `odoc link-deps`, we now assume that linking dependencies are the same as for compiling.

I refactored input detection to share it between both phases and added a test.
