### PR TITLE
 Nicer and safer way to generate Makefiles

### DIFF
--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -35,9 +35,6 @@ let compile_fragment all_infos info =
             include_str;
         ];
       phony_rule ("compile-" ^ info.package) ~fdeps:[ odoc_path ] [];
-      rule
-        (Fpath.v (Format.asprintf "Makefile.%s.link" info.package))
-        ~fdeps:[ odoc_path ] [];
     ]
 
 let gen inputs =

--- a/lib/gen.ml
+++ b/lib/gen.ml
@@ -1,8 +1,10 @@
 let run whitelist roots docroots =
   let inputs = Inputs.find_inputs ~whitelist (roots @ docroots) in
   let oc = open_out "Makefile.gen" in
+  let fmt = Format.formatter_of_out_channel oc in
   Fun.protect
-    ~finally:(fun () -> close_out oc)
+    ~finally:(fun () ->
+      Format.pp_print_flush fmt ();
+      close_out oc)
     (fun () ->
-      Compile.gen oc inputs;
-      Link.gen oc inputs)
+      Makefile.(pp fmt (concat [ Compile.gen inputs; Link.gen inputs ])))

--- a/lib/makefile.ml
+++ b/lib/makefile.ml
@@ -1,0 +1,50 @@
+type rule = {
+  target : string;
+  deps : string list;
+  oo_deps : string list;
+  recipe : string list;
+}
+
+type t = Rule of rule | Concat of t list | Include of string
+
+let concat ts = Concat ts
+
+let rule' target ?(fdeps = []) ?(deps = []) ?(oo_deps = []) recipe =
+  let deps = List.map Fpath.to_string fdeps @ deps in
+  Rule { target; deps; oo_deps; recipe }
+
+let rule target ?fdeps ?deps ?oo_deps recipe =
+  let target = Fpath.to_string target in
+  rule' target ?fdeps ?deps ?oo_deps recipe
+
+let phony_rule target ?fdeps ?deps ?oo_deps recipe =
+  Concat
+    [
+      rule' target ?fdeps ?deps ?oo_deps recipe;
+      rule' ".PHONY" ~deps:[ target ] [];
+    ]
+
+let include_ p = Include (Fpath.to_string p)
+
+let pp_rule fmt t =
+  let open Format in
+  let pp_deps =
+    let pp_sep fmt () = pp_print_string fmt " " in
+    pp_print_list ~pp_sep pp_print_string
+  in
+  let pp_oo_deps fmt = function
+    | [] -> ()
+    | deps -> fprintf fmt " | %a" pp_deps deps
+  in
+  let pp_recipe fmt = List.iter (fprintf fmt "\t%s@\n") in
+  fprintf fmt "%s : %a%a@\n%a" t.target pp_deps t.deps pp_oo_deps t.oo_deps
+    pp_recipe t.recipe
+
+let pp_include fmt p = Format.fprintf fmt "-include %s@\n" p
+
+let rec pp fmt = function
+  | Rule rule -> pp_rule fmt rule
+  | Concat ts ->
+      let pp_sep = Format.pp_print_newline in
+      Format.pp_print_list ~pp_sep pp fmt ts
+  | Include p -> pp_include fmt p

--- a/lib/makefile.mli
+++ b/lib/makefile.mli
@@ -1,0 +1,12 @@
+type t
+
+val concat : t list -> t
+
+(** [oo_deps] is order-only dependencies. *)
+val rule : Fpath.t -> ?fdeps:Fpath.t list -> ?deps:string list -> ?oo_deps:string list -> string list -> t
+
+val phony_rule : string -> ?fdeps:Fpath.t list -> ?deps:string list -> ?oo_deps:string list -> string list -> t
+
+val include_ : Fpath.t -> t
+
+val pp : Format.formatter -> t -> unit

--- a/test/dune_with_mld.t/run.t
+++ b/test/dune_with_mld.t/run.t
@@ -31,6 +31,10 @@ A basic test for working with Dune's _build/install.
   Warning, couldn't find dep Stdlib of file _build/install/default/lib/test/test.cmti
 
   $ make html
+  odoc compile --package default _build/install/default/doc/test/odoc-pages/test.mld  -o odocs/default/doc/test/odoc-pages/page-test.odoc
+  odoc compile --package default _build/install/default/lib/test/test.cmti  -o odocs/default/lib/test/test.odoc
+  odoc link odocs/default/doc/test/odoc-pages/page-test.odoc -o odocls/default/doc/test/odoc-pages/page-test.odocl -I odocs/default/doc/test/odoc-pages/ -I odocs/default/lib/test/
+  odoc link odocs/default/lib/test/test.odoc -o odocls/default/lib/test/test.odocl -I odocs/default/doc/test/odoc-pages/ -I odocs/default/lib/test/
   Starting link
   odocmkgen generate --package default
   odoc support-files --output-dir html

--- a/test/example.t/run.t
+++ b/test/example.t/run.t
@@ -10,8 +10,12 @@ The driver works on compiled files:
   Warning, couldn't find dep Stdlib of file ./b/b.cmi
   Warning, couldn't find dep CamlinternalFormatBasics of file ./a/a.cmi
   Warning, couldn't find dep Stdlib of file ./a/a.cmi
+  odoc compile --package b b/b.cmi  -o odocs/b/b.odoc
+  odoc link odocs/b/b.odoc -o odocls/b/b.odocl -I odocs/b/
   Starting link
   odocmkgen generate --package b
+  odoc compile --package a a/a.cmi  -o odocs/a/a.odoc
+  odoc link odocs/a/a.odoc -o odocls/a/a.odocl -I odocs/a/
   Starting link
   odocmkgen generate --package a
   odoc support-files --output-dir html


### PR DESCRIPTION
Contains https://github.com/jonludlam/odocmkgen/pull/6, which must be merged first

This adds a safe interface to write Makefiles. The advantages are that there is less opportunities to generate bad Makefiles and that the code is more maintainable (less `Fpath.to_string` and `String.concat`, no multiline format strings, more types).
Also, output will be more consistent (always using the same formatting).

I removed every `@` prefixing recipes because there were not present in every rules. We could add them back but I think it's bad practice to try to control make's output.