### PR TITLE
Change the package detection logic

### DIFF
--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -20,8 +20,9 @@ let compile_fragment all_infos info =
 
   (* Odoc requires the directories in which to find the odoc files of the dependencies *)
   let include_str =
-    List.map Fpath.(fun p -> to_string (parent p)) dep_odocs
-    |> List.sort_uniq String.compare
+    List.map Fpath.parent dep_odocs
+    |> List.sort_uniq Fpath.compare
+    |> List.map (Format.asprintf "-I %a" Fpath.pp)
     |> String.concat " "
   in
 

--- a/lib/inputs.ml
+++ b/lib/inputs.ml
@@ -10,6 +10,10 @@ let filter pred item = if pred item then [item] else []
 
 let is_dir x = Sys.is_directory (Fpath.to_string x)
 
+let dir_exists x =
+  let p = Fpath.to_string x in
+  Sys.file_exists p && Sys.is_directory p
+
 let has_ext exts f =
   List.exists (fun suffix -> Fpath.has_ext suffix f) exts
 
@@ -131,7 +135,7 @@ let find_inputs ~whitelist roots =
       | Some (pkg, prefix) ->
           (* This directory may not exist *)
           let doc_dir = Fpath.(prefix / "doc" / pkg) in
-          (pkg, if is_dir doc_dir then Some doc_dir else None)
+          (pkg, if dir_exists doc_dir then Some doc_dir else None)
       | None ->
           (* In case [root] is not recognized as a package, use the basename
              instead. This may be wrong sometimes. *)
@@ -139,7 +143,8 @@ let find_inputs ~whitelist roots =
     in
     let doc_inputs =
       match doc_dir with
-      | Some doc_dir -> find_files doc_dir >>= get_mld_info ~package doc_dir
+      | Some doc_dir ->
+          get_mld_files (find_files doc_dir) >>= get_mld_info ~package doc_dir
       | None -> []
     in
     (* [doc_files] also contains [README.md], [CHANGES.md] and other common

--- a/test/dune_with_mld.t/run.t
+++ b/test/dune_with_mld.t/run.t
@@ -25,25 +25,31 @@ A basic test for working with Dune's _build/install.
   _build/install/default/lib/test/test.mli
   _build/install/default/lib/test/dune-package
 
-  $ odocmkgen -D _build/install -L _build/install > Makefile
-  $ odocmkgen gen -D _build/install -L _build/install
-  Warning, couldn't find dep CamlinternalFormatBasics of file _build/install/default/lib/test/test.cmti
-  Warning, couldn't find dep Stdlib of file _build/install/default/lib/test/test.cmti
+Use paths found by findlib:
+
+  $ P=$(dune exec -- ocamlfind query test)
+  $ echo "$P"
+  $TESTCASE_ROOT/_build/install/default/lib/test
+
+  $ odocmkgen -D "$P" -L "$P" > Makefile
+  $ odocmkgen gen -D "$P" -L "$P"
+  Warning, couldn't find dep CamlinternalFormatBasics of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
+  Warning, couldn't find dep Stdlib of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
 
   $ make html
-  odoc compile --package default _build/install/default/doc/test/odoc-pages/test.mld  -o odocs/default/doc/test/odoc-pages/page-test.odoc
-  odoc compile --package default _build/install/default/lib/test/test.cmti  -o odocs/default/lib/test/test.odoc
-  odoc link odocs/default/doc/test/odoc-pages/page-test.odoc -o odocls/default/doc/test/odoc-pages/page-test.odocl -I odocs/default/doc/test/odoc-pages/ -I odocs/default/lib/test/
-  odoc link odocs/default/lib/test/test.odoc -o odocls/default/lib/test/test.odocl -I odocs/default/doc/test/odoc-pages/ -I odocs/default/lib/test/
+  odoc compile --package test $TESTCASE_ROOT/_build/install/default/doc/test/odoc-pages/test.mld  -o odocs/test/odoc-pages/page-test.odoc
+  odoc compile --package test $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti  -o odocs/test/test.odoc
+  odoc link odocs/test/odoc-pages/page-test.odoc -o odocls/test/odoc-pages/page-test.odocl -I odocs/test/ -I odocs/test/odoc-pages/
+  odoc link odocs/test/test.odoc -o odocls/test/test.odocl -I odocs/test/ -I odocs/test/odoc-pages/
   Starting link
-  odocmkgen generate --package default
+  odocmkgen generate --package test
   odoc support-files --output-dir html
-  odoc html-generate odocls/default/doc/test/odoc-pages/page-test.odocl --output-dir html
-  odoc html-generate odocls/default/lib/test/test.odocl --output-dir html
+  odoc html-generate odocls/test/test.odocl --output-dir html
+  odoc html-generate odocls/test/odoc-pages/page-test.odocl --output-dir html
 
   $ jq_scan_references() { jq -c '.. | .["`Reference"]? | select(.) | .[0]'; }
 
 Doesn't resolve but should:
 
-  $ odoc_print odocls/default/doc/test/odoc-pages/page-test.odocl | jq_scan_references
+  $ odoc_print odocls/test/odoc-pages/page-test.odocl | jq_scan_references
   {"`Resolved":{"`Value":[{"`Identifier":{"`Root":["<root>","Test"]}},"x"]}}

--- a/test/example.t/run.t
+++ b/test/example.t/run.t
@@ -2,14 +2,14 @@ The driver works on compiled files:
 
   $ ocamlc -I b -I a b/b.mli b/b.ml a/a.mli a/a.ml
 
-  $ odocmkgen -L . -D . > Makefile
+  $ odocmkgen -L a -L b -D a > Makefile
 
   $ make html
-  odocmkgen gen -L . -D .
-  Warning, couldn't find dep CamlinternalFormatBasics of file ./b/b.cmi
-  Warning, couldn't find dep Stdlib of file ./b/b.cmi
-  Warning, couldn't find dep CamlinternalFormatBasics of file ./a/a.cmi
-  Warning, couldn't find dep Stdlib of file ./a/a.cmi
+  odocmkgen gen -L a -L b -D a
+  Warning, couldn't find dep CamlinternalFormatBasics of file a/a.cmi
+  Warning, couldn't find dep Stdlib of file a/a.cmi
+  Warning, couldn't find dep CamlinternalFormatBasics of file b/b.cmi
+  Warning, couldn't find dep Stdlib of file b/b.cmi
   odoc compile --package b b/b.cmi  -o odocs/b/b.odoc
   odoc link odocs/b/b.odoc -o odocls/b/b.odocl -I odocs/b/
   Starting link


### PR DESCRIPTION
Now expects paths like `prefix/lib/package` or `prefix/lib/package/sub_dir`, these are paths returned by findlib.
Documentation is expected in `prefix/doc/package`.

Paths that doesn't look like that continue to work as before but inputs are no longer searched recursively.