### PR TITLE
Remove -L and -D options

### DIFF
--- a/lib/gen.ml
+++ b/lib/gen.ml
@@ -1,5 +1,5 @@
-let run whitelist roots docroots =
-  let inputs = Inputs.find_inputs ~whitelist (roots @ docroots) in
+let run whitelist roots =
+  let inputs = Inputs.find_inputs ~whitelist roots in
   let oc = open_out "Makefile.gen" in
   let fmt = Format.formatter_of_out_channel oc in
   Fun.protect

--- a/test/dune_with_mld.t/run.t
+++ b/test/dune_with_mld.t/run.t
@@ -31,12 +31,12 @@ Use paths found by findlib:
   $ echo "$P"
   $TESTCASE_ROOT/_build/install/default/lib/test
 
-  $ odocmkgen -D "$P" -L "$P" > Makefile
-  $ odocmkgen gen -D "$P" -L "$P"
-  Warning, couldn't find dep CamlinternalFormatBasics of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
-  Warning, couldn't find dep Stdlib of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
+  $ odocmkgen -- "$P" > Makefile
 
   $ make html
+  odocmkgen gen $TESTCASE_ROOT/_build/install/default/lib/test
+  Warning, couldn't find dep CamlinternalFormatBasics of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
+  Warning, couldn't find dep Stdlib of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
   odoc compile --package test $TESTCASE_ROOT/_build/install/default/doc/test/odoc-pages/test.mld  -o odocs/test/odoc-pages/page-test.odoc
   odoc compile --package test $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti  -o odocs/test/test.odoc
   odoc link odocs/test/odoc-pages/page-test.odoc -o odocls/test/odoc-pages/page-test.odocl -I odocs/test/ -I odocs/test/odoc-pages/

--- a/test/example.t/run.t
+++ b/test/example.t/run.t
@@ -2,10 +2,10 @@ The driver works on compiled files:
 
   $ ocamlc -I b -I a b/b.mli b/b.ml a/a.mli a/a.ml
 
-  $ odocmkgen -L a -L b -D a > Makefile
+  $ odocmkgen -- a b > Makefile
 
   $ make html
-  odocmkgen gen -L a -L b -D a
+  odocmkgen gen a b
   Warning, couldn't find dep CamlinternalFormatBasics of file a/a.cmi
   Warning, couldn't find dep Stdlib of file a/a.cmi
   Warning, couldn't find dep CamlinternalFormatBasics of file b/b.cmi


### PR DESCRIPTION
The `-D` option isn't meaningful since the recent changes. The default value is also wrong, we now need paths given by `ocamlfind query`.

I changed the `-L` option into a list of positional arguments but this conflicts with sub commands and it is necessary to write
`odocmkgen -- /paths`

Instead of fixing this, I think it'd be better to add a new sub-command for generating the initial `Makefile`.
The default command would show the man page, I think this is better for complicated and rarely-used programs.