### PR TITLE
Safer API for writing shell commands

### DIFF
--- a/lib/makefile.ml
+++ b/lib/makefile.ml
@@ -5,12 +5,17 @@ type rule = {
   recipe : string list;
 }
 
+type cmd = string list -> string
+
 type t = Rule of rule | Concat of t list | Include of string
+
+let cmd_to_string cmd = cmd []
 
 let concat ts = Concat ts
 
 let rule' target ?(fdeps = []) ?(deps = []) ?(oo_deps = []) recipe =
   let deps = List.map Fpath.to_string fdeps @ deps in
+  let recipe = List.map cmd_to_string recipe in
   Rule { target; deps; oo_deps; recipe }
 
 let rule target ?fdeps ?deps ?oo_deps recipe =
@@ -48,3 +53,10 @@ let rec pp fmt = function
       let pp_sep = Format.pp_print_newline in
       Format.pp_print_list ~pp_sep pp fmt ts
   | Include p -> pp_include fmt p
+
+let cmd ?stdin ?stdout ?stderr cmd acc =
+  Filename.quote_command cmd ?stdin ?stdout ?stderr acc
+
+let ( $ ) cmd arg acc = cmd (arg :: acc)
+
+let ( $$ ) cmd args acc = cmd (args @ acc)

--- a/lib/makefile.mli
+++ b/lib/makefile.mli
@@ -1,12 +1,36 @@
+(** This module is meant to be opened locally. *)
+
 type t
+(** A fragment of a Makefile *)
+
+type cmd
 
 val concat : t list -> t
 
+val rule :
+  Fpath.t ->
+  ?fdeps:Fpath.t list ->
+  ?deps:string list ->
+  ?oo_deps:string list ->
+  cmd list ->
+  t
 (** [oo_deps] is order-only dependencies. *)
-val rule : Fpath.t -> ?fdeps:Fpath.t list -> ?deps:string list -> ?oo_deps:string list -> string list -> t
 
-val phony_rule : string -> ?fdeps:Fpath.t list -> ?deps:string list -> ?oo_deps:string list -> string list -> t
+val phony_rule :
+  string ->
+  ?fdeps:Fpath.t list ->
+  ?deps:string list ->
+  ?oo_deps:string list ->
+  cmd list ->
+  t
 
 val include_ : Fpath.t -> t
 
 val pp : Format.formatter -> t -> unit
+
+(** Create a [cmd]. Use {!($)} and {!($$)} to concatenate arguments. *)
+val cmd : ?stdin:string -> ?stdout:string -> ?stderr:string -> string -> cmd
+
+val ( $ ) : cmd -> string -> cmd
+
+val ( $$ ) : cmd -> string list -> cmd

--- a/test/dune_with_mld.t/run.t
+++ b/test/dune_with_mld.t/run.t
@@ -11,19 +11,19 @@ A basic test for working with Dune's _build/install.
   _build/install/default/doc/test/odoc-pages/test.mld
   _build/install/default/lib
   _build/install/default/lib/test
-  _build/install/default/lib/test/META
-  _build/install/default/lib/test/test.cmx
-  _build/install/default/lib/test/test.a
-  _build/install/default/lib/test/test.cmxs
-  _build/install/default/lib/test/test.cma
-  _build/install/default/lib/test/test.cmt
-  _build/install/default/lib/test/test.cmi
   _build/install/default/lib/test/test.cmxa
   _build/install/default/lib/test/test.cmti
-  _build/install/default/lib/test/opam
   _build/install/default/lib/test/test.ml
+  _build/install/default/lib/test/opam
+  _build/install/default/lib/test/test.cmx
+  _build/install/default/lib/test/test.a
+  _build/install/default/lib/test/test.cma
   _build/install/default/lib/test/test.mli
+  _build/install/default/lib/test/META
+  _build/install/default/lib/test/test.cmi
+  _build/install/default/lib/test/test.cmxs
   _build/install/default/lib/test/dune-package
+  _build/install/default/lib/test/test.cmt
 
 Use paths found by findlib:
 
@@ -37,12 +37,13 @@ Use paths found by findlib:
   odocmkgen gen $TESTCASE_ROOT/_build/install/default/lib/test
   Warning, couldn't find dep CamlinternalFormatBasics of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
   Warning, couldn't find dep Stdlib of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
-  odoc compile --package test $TESTCASE_ROOT/_build/install/default/doc/test/odoc-pages/test.mld  -o odocs/test/odoc-pages/page-test.odoc
-  odoc compile --package test $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti  -o odocs/test/test.odoc
-  odoc link odocs/test/odoc-pages/page-test.odoc -o odocls/test/odoc-pages/page-test.odocl -I odocs/test/ -I odocs/test/odoc-pages/
-  odoc link odocs/test/test.odoc -o odocls/test/test.odocl -I odocs/test/ -I odocs/test/odoc-pages/
-  Starting link
-  odocmkgen generate --package test
+  'odoc' 'compile' '--package' 'test' '$TESTCASE_ROOT/_build/install/default/doc/test/odoc-pages/test.mld' '-o' 'odocs/test/odoc-pages/page-test.odoc'
+  'odoc' 'compile' '--package' 'test' '$TESTCASE_ROOT/_build/install/default/lib/test/test.cmti' '-o' 'odocs/test/test.odoc'
+  'odoc' 'link' 'odocs/test/odoc-pages/page-test.odoc' '-o' 'odocls/test/odoc-pages/page-test.odocl' '-I' 'odocs/test/' '-I' 'odocs/test/odoc-pages/'
+  'odoc' 'link' 'odocs/test/test.odoc' '-o' 'odocls/test/test.odocl' '-I' 'odocs/test/' '-I' 'odocs/test/odoc-pages/'
+  'odocmkgen' 'generate' '--package' 'test'
+  dir=test file=Test
+  dir=test file=test
   odoc support-files --output-dir html
   odoc html-generate odocls/test/test.odocl --output-dir html
   odoc html-generate odocls/test/odoc-pages/page-test.odocl --output-dir html
@@ -52,4 +53,4 @@ Use paths found by findlib:
 Doesn't resolve but should:
 
   $ odoc_print odocls/test/odoc-pages/page-test.odocl | jq_scan_references
-  {"`Resolved":{"`Value":[{"`Identifier":{"`Root":["<root>","Test"]}},"x"]}}
+  {"`Resolved":{"`Value":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"Test"]}},"x"]}}

--- a/test/example.t/run.t
+++ b/test/example.t/run.t
@@ -10,14 +10,14 @@ The driver works on compiled files:
   Warning, couldn't find dep Stdlib of file a/a.cmi
   Warning, couldn't find dep CamlinternalFormatBasics of file b/b.cmi
   Warning, couldn't find dep Stdlib of file b/b.cmi
-  odoc compile --package b b/b.cmi  -o odocs/b/b.odoc
-  odoc link odocs/b/b.odoc -o odocls/b/b.odocl -I odocs/b/
-  Starting link
-  odocmkgen generate --package b
-  odoc compile --package a a/a.cmi  -o odocs/a/a.odoc
-  odoc link odocs/a/a.odoc -o odocls/a/a.odocl -I odocs/a/
-  Starting link
-  odocmkgen generate --package a
+  'odoc' 'compile' '--package' 'b' 'b/b.cmi' '-o' 'odocs/b/b.odoc'
+  'odoc' 'link' 'odocs/b/b.odoc' '-o' 'odocls/b/b.odocl' '-I' 'odocs/b/'
+  'odocmkgen' 'generate' '--package' 'b'
+  dir=b file=B
+  'odoc' 'compile' '--package' 'a' 'a/a.cmi' '-o' 'odocs/a/a.odoc'
+  'odoc' 'link' 'odocs/a/a.odoc' '-o' 'odocls/a/a.odocl' '-I' 'odocs/a/'
+  'odocmkgen' 'generate' '--package' 'a'
+  dir=a file=A
   odoc support-files --output-dir html
   odoc html-generate odocls/a/a.odocl --output-dir html
   odoc html-generate odocls/b/b.odocl --output-dir html


### PR DESCRIPTION
Use an abstract type and an operator of the right precedence to write
commands instead of string concatenations and hope.

Commands are then constructed with `Filename.quote_command`, which
ensures that the command is correctly quoted but has drawbacks:

- Different outputs on Windows (without Cygwin).
  The advantage is that our Makefiles can be run with cmd.exe but people are probably expecting it to use bash syntax and unix tools
  (eg. an alternative to Cygwin that the stdlib doesn't know about).

- Too much quotes makes ugly output, for example:
  ```diff
  -  	odoc compile --package test $<  -o $@
  +  	'odoc' 'compile' '--package' 'test' '$<' '-o' '$@'
  ```
  Make's variables are still expended.