### PR TITLE
Split the generate step and make the Makefiles standalone

### DIFF
--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -29,7 +29,7 @@ let compile_fragment all_infos info =
   let open Makefile in
   concat
     [
-      rule odoc_path
+      rule [ odoc_path ]
         ~fdeps:(Inputs.input_file info :: dep_odocs)
         [
           cmd "odoc" $ "compile" $ "--package" $ info.package $ "$<"

--- a/lib/generate.ml
+++ b/lib/generate.ml
@@ -1,41 +1,48 @@
 open Listm
 
-let paths_of_package all_files package =
-  let all_paths =
-    all_files >>= fun file ->
-    match Fpath.(segs (normalize file)) with
-    | "odocls" :: pkg :: _ when pkg = package -> [Fpath.add_ext "odocl" file]
-    | _ -> []
+let output_dir = function `Html -> "html" | `Latex -> "latex" | `Man -> "man"
+
+let generate_command = function
+  | `Html -> "html-generate"
+  | `Latex -> "latex-generate"
+  | `Man -> "man-generate"
+
+let make_target = function `Html -> "html" | `Latex -> "latex" | `Man -> "man"
+
+let mk_pkg target path =
+  let files =
+    Inputs.find_files path >>= fun p ->
+    if Fpath.has_ext ".odocl" p then [ p ] else []
   in
-  setify all_paths
+  List.map
+    (fun f ->
+      let outputs = List.map Fpath.v (Odoc.generate_targets f target) in
+      Makefile.(
+        concat
+          [
+            phony_rule (make_target target) ~fdeps:outputs [];
+            rule outputs ~fdeps:[ f ]
+              [
+                cmd "odoc" $ generate_command target $ "--output-dir"
+                $ output_dir target $ "$<";
+              ];
+          ]))
+    files
+  |> Makefile.concat
 
-let run path package =
-  let package_makefile = Printf.sprintf "Makefile.%s.generate" package in
+let prelude =
+  let open Makefile in
+  let odoc_css = Fpath.v "html/odoc.css" in
+  concat
+    [
+      phony_rule "default" ~deps:[ "html" ] [];
+      phony_rule "html" ~fdeps:[ odoc_css ] [];
+      rule [ odoc_css ] [ cmd "odoc" $ "support-files" $ "--output-dir" $ "html" ];
+    ]
 
-  let all_files = Inputs.find_files path >>= fun p ->
-    let base, ext = Fpath.split_ext p in
-    if ext = ".odocl" then [ base ] else []
+let run paths =
+  let makefile =
+    let mk target = Makefile.concat (List.map (mk_pkg target) paths) in
+    Makefile.concat [ prelude; mk `Html; mk `Latex; mk `Man ]
   in
-
-  let pkg_files = paths_of_package all_files package in
-
-  let oc = open_out package_makefile in
-
-  let mk format =
-    List.iter
-      (fun f ->
-        let str_format = match format with | `Html -> "html" | `Latex -> "latex" | `Man -> "man" in
-        let targets = Odoc.generate_targets f format in
-        let str = Format.asprintf "%s &: %a\n\todoc %s-generate %a --output-dir %s\n" (String.concat " " targets) Fpath.pp f str_format Fpath.pp f str_format in
-        Printf.fprintf oc "%s" str;
-        let str = Format.asprintf "%s : %s\n" str_format (String.concat " " targets) in
-        Printf.fprintf oc "%s" str
-        ) pkg_files;
-  in
-
-  mk `Html;
-  mk `Latex;
-  mk `Man;
-
-  close_out oc
-
+  Format.printf "%a\n" Makefile.pp makefile

--- a/lib/link.ml
+++ b/lib/link.ml
@@ -80,17 +80,7 @@ let gen (inputs : Inputs.t list) =
   StringMap.fold
     (fun package inputs acc ->
       let package_deps = package :: StringMap.find package package_deps in
-      let output_files = List.map Inputs.link_target inputs in
-      let pkg_makefile =
-        Fpath.v (Format.asprintf "Makefile.%s.generate" package)
-      in
       let open Makefile in
       concat
-        [
-          acc;
-          concat (List.map (gen_input ~packages ~package_deps) inputs);
-          rule [ pkg_makefile ] ~fdeps:output_files
-            [ cmd "odocmkgen" $ "generate" $ "--package" $ package ];
-          include_ pkg_makefile;
-        ])
+        [ acc; concat (List.map (gen_input ~packages ~package_deps) inputs) ])
     packages (Makefile.concat [])

--- a/lib/link.ml
+++ b/lib/link.ml
@@ -32,7 +32,7 @@ let gen_input ~packages ~package_deps inp =
   in
   concat
     [
-      rule output_file ~fdeps:[ input_file ] ~oo_deps:compile_pkg_deps
+      rule [ output_file ] ~fdeps:[ input_file ] ~oo_deps:compile_pkg_deps
         [ cmd "odoc" $ "link" $ "$<" $ "-o" $ "$@" $$ inc_args ];
       phony_rule "link" ~fdeps:[ output_file ] [];
     ]
@@ -89,7 +89,7 @@ let gen (inputs : Inputs.t list) =
         [
           acc;
           concat (List.map (gen_input ~packages ~package_deps) inputs);
-          rule pkg_makefile ~fdeps:output_files
+          rule [ pkg_makefile ] ~fdeps:output_files
             [ cmd "odocmkgen" $ "generate" $ "--package" $ package ];
           include_ pkg_makefile;
         ])

--- a/lib/makefile.ml
+++ b/lib/makefile.ml
@@ -1,5 +1,5 @@
 type rule = {
-  target : string;
+  targets : string list;
   deps : string list;
   oo_deps : string list;
   recipe : string list;
@@ -13,20 +13,20 @@ let cmd_to_string cmd = cmd []
 
 let concat ts = Concat ts
 
-let rule' target ?(fdeps = []) ?(deps = []) ?(oo_deps = []) recipe =
+let rule' targets ?(fdeps = []) ?(deps = []) ?(oo_deps = []) recipe =
   let deps = List.map Fpath.to_string fdeps @ deps in
   let recipe = List.map cmd_to_string recipe in
-  Rule { target; deps; oo_deps; recipe }
+  Rule { targets; deps; oo_deps; recipe }
 
-let rule target ?fdeps ?deps ?oo_deps recipe =
-  let target = Fpath.to_string target in
-  rule' target ?fdeps ?deps ?oo_deps recipe
+let rule targets ?fdeps ?deps ?oo_deps recipe =
+  let targets = List.map Fpath.to_string targets in
+  rule' targets ?fdeps ?deps ?oo_deps recipe
 
 let phony_rule target ?fdeps ?deps ?oo_deps recipe =
   Concat
     [
-      rule' target ?fdeps ?deps ?oo_deps recipe;
-      rule' ".PHONY" ~deps:[ target ] [];
+      rule' [ target ] ?fdeps ?deps ?oo_deps recipe;
+      rule' [ ".PHONY" ] ~deps:[ target ] [];
     ]
 
 let include_ p = Include (Fpath.to_string p)
@@ -42,8 +42,9 @@ let pp_rule fmt t =
     | deps -> fprintf fmt " | %a" pp_deps deps
   in
   let pp_recipe fmt = List.iter (fprintf fmt "\t%s@\n") in
-  fprintf fmt "%s : %a%a@\n%a" t.target pp_deps t.deps pp_oo_deps t.oo_deps
-    pp_recipe t.recipe
+  fprintf fmt "%a : %a%a@\n%a"
+    (pp_print_list pp_print_string)
+    t.targets pp_deps t.deps pp_oo_deps t.oo_deps pp_recipe t.recipe
 
 let pp_include fmt p = Format.fprintf fmt "-include %s@\n" p
 

--- a/lib/makefile.mli
+++ b/lib/makefile.mli
@@ -8,7 +8,7 @@ type cmd
 val concat : t list -> t
 
 val rule :
-  Fpath.t ->
+  Fpath.t list ->
   ?fdeps:Fpath.t list ->
   ?deps:string list ->
   ?oo_deps:string list ->

--- a/test/dune_with_mld.t/run.t
+++ b/test/dune_with_mld.t/run.t
@@ -9,15 +9,14 @@ Use paths found by findlib:
   $TESTCASE_ROOT/_build/install/default/lib/test
 
   $ odocmkgen -- "$P" > Makefile
-
-  $ make
-  odocmkgen gen $TESTCASE_ROOT/_build/install/default/lib/test
   Warning, couldn't find dep CamlinternalFormatBasics of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
   Warning, couldn't find dep Stdlib of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
-  mkdir odocs
+
+  $ make
+  'mkdir' 'odocs'
   'odoc' 'compile' '--package' 'test' '$TESTCASE_ROOT/_build/install/default/lib/test/test.cmti' '-o' 'odocs/test/test.odoc'
   'odoc' 'compile' '--package' 'test' '$TESTCASE_ROOT/_build/install/default/doc/test/odoc-pages/test.mld' '-o' 'odocs/test/odoc-pages/page-test.odoc'
-  mkdir odocls
+  'mkdir' 'odocls'
   'odoc' 'link' 'odocs/test/odoc-pages/page-test.odoc' '-o' 'odocls/test/odoc-pages/page-test.odocl' '-I' 'odocs/test/' '-I' 'odocs/test/odoc-pages/'
   'odoc' 'link' 'odocs/test/test.odoc' '-o' 'odocls/test/test.odocl' '-I' 'odocs/test/' '-I' 'odocs/test/odoc-pages/'
 

--- a/test/dune_with_mld.t/run.t
+++ b/test/dune_with_mld.t/run.t
@@ -2,29 +2,6 @@ A basic test for working with Dune's _build/install.
 
   $ dune build -p test
 
-  $ find _build/install
-  _build/install
-  _build/install/default
-  _build/install/default/doc
-  _build/install/default/doc/test
-  _build/install/default/doc/test/odoc-pages
-  _build/install/default/doc/test/odoc-pages/test.mld
-  _build/install/default/lib
-  _build/install/default/lib/test
-  _build/install/default/lib/test/test.cmxa
-  _build/install/default/lib/test/test.cmti
-  _build/install/default/lib/test/test.ml
-  _build/install/default/lib/test/opam
-  _build/install/default/lib/test/test.cmx
-  _build/install/default/lib/test/test.a
-  _build/install/default/lib/test/test.cma
-  _build/install/default/lib/test/test.mli
-  _build/install/default/lib/test/META
-  _build/install/default/lib/test/test.cmi
-  _build/install/default/lib/test/test.cmxs
-  _build/install/default/lib/test/dune-package
-  _build/install/default/lib/test/test.cmt
-
 Use paths found by findlib:
 
   $ P=$(dune exec -- ocamlfind query test)
@@ -33,20 +10,16 @@ Use paths found by findlib:
 
   $ odocmkgen -- "$P" > Makefile
 
-  $ make html
+  $ make
   odocmkgen gen $TESTCASE_ROOT/_build/install/default/lib/test
   Warning, couldn't find dep CamlinternalFormatBasics of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
   Warning, couldn't find dep Stdlib of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
-  'odoc' 'compile' '--package' 'test' '$TESTCASE_ROOT/_build/install/default/doc/test/odoc-pages/test.mld' '-o' 'odocs/test/odoc-pages/page-test.odoc'
+  mkdir odocs
   'odoc' 'compile' '--package' 'test' '$TESTCASE_ROOT/_build/install/default/lib/test/test.cmti' '-o' 'odocs/test/test.odoc'
+  'odoc' 'compile' '--package' 'test' '$TESTCASE_ROOT/_build/install/default/doc/test/odoc-pages/test.mld' '-o' 'odocs/test/odoc-pages/page-test.odoc'
+  mkdir odocls
   'odoc' 'link' 'odocs/test/odoc-pages/page-test.odoc' '-o' 'odocls/test/odoc-pages/page-test.odocl' '-I' 'odocs/test/' '-I' 'odocs/test/odoc-pages/'
   'odoc' 'link' 'odocs/test/test.odoc' '-o' 'odocls/test/test.odocl' '-I' 'odocs/test/' '-I' 'odocs/test/odoc-pages/'
-  'odocmkgen' 'generate' '--package' 'test'
-  dir=test file=Test
-  dir=test file=test
-  odoc support-files --output-dir html
-  odoc html-generate odocls/test/test.odocl --output-dir html
-  odoc html-generate odocls/test/odoc-pages/page-test.odocl --output-dir html
 
   $ jq_scan_references() { jq -c '.. | .["`Reference"]? | select(.) | .[0]'; }
 

--- a/test/example.t/run.t
+++ b/test/example.t/run.t
@@ -3,17 +3,16 @@ The driver works on compiled files:
   $ ocamlc -I b -I a b/b.mli b/b.ml a/a.mli a/a.ml
 
   $ odocmkgen -- a b > Makefile
-
-  $ make
-  odocmkgen gen a b
   Warning, couldn't find dep CamlinternalFormatBasics of file a/a.cmi
   Warning, couldn't find dep Stdlib of file a/a.cmi
   Warning, couldn't find dep CamlinternalFormatBasics of file b/b.cmi
   Warning, couldn't find dep Stdlib of file b/b.cmi
-  mkdir odocs
+
+  $ make
+  'mkdir' 'odocs'
   'odoc' 'compile' '--package' 'a' 'a/a.cmi' '-o' 'odocs/a/a.odoc'
   'odoc' 'compile' '--package' 'b' 'b/b.cmi' '-o' 'odocs/b/b.odoc'
-  mkdir odocls
+  'mkdir' 'odocls'
   'odoc' 'link' 'odocs/a/a.odoc' '-o' 'odocls/a/a.odocl' '-I' 'odocs/a/'
   'odoc' 'link' 'odocs/b/b.odoc' '-o' 'odocls/b/b.odocl' '-I' 'odocs/b/'
 

--- a/test/example.t/run.t
+++ b/test/example.t/run.t
@@ -4,26 +4,55 @@ The driver works on compiled files:
 
   $ odocmkgen -- a b > Makefile
 
-  $ make html
+  $ make
   odocmkgen gen a b
   Warning, couldn't find dep CamlinternalFormatBasics of file a/a.cmi
   Warning, couldn't find dep Stdlib of file a/a.cmi
   Warning, couldn't find dep CamlinternalFormatBasics of file b/b.cmi
   Warning, couldn't find dep Stdlib of file b/b.cmi
-  'odoc' 'compile' '--package' 'b' 'b/b.cmi' '-o' 'odocs/b/b.odoc'
-  'odoc' 'link' 'odocs/b/b.odoc' '-o' 'odocls/b/b.odocl' '-I' 'odocs/b/'
-  'odocmkgen' 'generate' '--package' 'b'
-  dir=b file=B
+  mkdir odocs
   'odoc' 'compile' '--package' 'a' 'a/a.cmi' '-o' 'odocs/a/a.odoc'
+  'odoc' 'compile' '--package' 'b' 'b/b.cmi' '-o' 'odocs/b/b.odoc'
+  mkdir odocls
   'odoc' 'link' 'odocs/a/a.odoc' '-o' 'odocls/a/a.odocl' '-I' 'odocs/a/'
-  'odocmkgen' 'generate' '--package' 'a'
-  dir=a file=A
-  odoc support-files --output-dir html
-  odoc html-generate odocls/a/a.odocl --output-dir html
-  odoc html-generate odocls/b/b.odocl --output-dir html
+  'odoc' 'link' 'odocs/b/b.odoc' '-o' 'odocls/b/b.odocl' '-I' 'odocs/b/'
 
-  $ ls Makefile*
-  Makefile
-  Makefile.a.generate
-  Makefile.b.generate
-  Makefile.gen
+  $ odocmkgen generate odocls/* > Makefile.generate
+  dir=a file=A
+  dir=b file=B
+
+  $ make -f Makefile.generate html
+  'odoc' 'support-files' '--output-dir' 'html'
+  'odoc' 'html-generate' '--output-dir' 'html' 'odocls/a/a.odocl'
+  'odoc' 'html-generate' '--output-dir' 'html' 'odocls/b/b.odocl'
+
+  $ make -f Makefile.generate latex
+  'odoc' 'latex-generate' '--output-dir' 'latex' 'odocls/a/a.odocl'
+  dir=a file=A
+  'odoc' 'latex-generate' '--output-dir' 'latex' 'odocls/b/b.odocl'
+  dir=b file=B
+
+  $ make -f Makefile.generate man
+  'odoc' 'man-generate' '--output-dir' 'man' 'odocls/a/a.odocl'
+  'odoc' 'man-generate' '--output-dir' 'man' 'odocls/b/b.odocl'
+
+  $ find html latex man | sort
+  html
+  html/a
+  html/a/A
+  html/a/A/index.html
+  html/b
+  html/b/B
+  html/b/B/index.html
+  html/highlight.pack.js
+  html/odoc.css
+  latex
+  latex/a
+  latex/a/A.tex
+  latex/b
+  latex/b/B.tex
+  man
+  man/a
+  man/a/A.3o
+  man/b
+  man/b/B.3o


### PR DESCRIPTION
This PR removes the initial Makefile, which was calling odocmkgen to generate the next step.
And removes the Makefiles generated for each packages for building the html/latex/man.

Now, `odocmkgen` or `odocmkgen gen` will generate (printed to stdout) a standalone Makefile doing the compile and link steps.
`odocmkgen generate odocls/*` (taking a list of paths, one per package) will generate a standalone Makefile that can build the final result.

I plan to change both commands to run on an arbitrary directory tree instead of a set of packages.