### PR TITLE
Add the 'prep' phase

### DIFF
--- a/lib/prepare_packages.ml
+++ b/lib/prepare_packages.ml
@@ -1,0 +1,60 @@
+(** This is a separate tool and doesn't interfere with the rest of odocmkgen.
+    It is linked into the same binary for convenience. *)
+
+open Util
+
+let copy_file ~dst ~src =
+  Format.eprintf "Copy '%a' -> '%a'\n" Fpath.pp src Fpath.pp dst;
+  ignore
+    (Process_util.lines_of_process
+       (Filename.quote_command "cp"
+          [ Fpath.to_string src; Fpath.to_string dst ]))
+
+(** Copy files from [src_dir] that satisfy [p] to [dst_dir].
+    Create [dst_dir] if needed. *)
+let copy_files_from src_dir ~dst_dir p =
+  match Fs_util.dir_contents src_dir with
+  | exception Sys_error _ -> ()
+  | [] -> ()
+  | srcs ->
+      Fs_util.mkdir_rec dst_dir;
+      List.iter
+        (fun src ->
+          if p src then
+            let dst = Fpath.append dst_dir (Fpath.base src) in
+            copy_file ~dst ~src)
+        srcs
+
+let prepare_doc dst_dir src =
+  (* TODO: Common files in [src]: Readme, changes, license (.md, .org, no ext) *)
+  (* TODO: Other files: example files (.ml), manuals and markdown doc *)
+  copy_files_from Fpath.(src / "odoc-pages") ~dst_dir (Fpath.has_ext ".mld")
+
+let prepare_lib dst_dir src =
+  copy_files_from src ~dst_dir (Fpath.mem_ext [ ".cmti"; ".cmt"; ".cmi" ])
+
+(** Expect paths containing a 'lib' segment, other paths are ignored. *)
+let find_root path =
+  match List_util.split_at_right (( = ) "lib") (Fpath.segs path) with
+  | Some (root, _, relpath) -> Some (path_of_segs root, path_of_segs relpath)
+  | None -> None
+
+let prepare_package dst_dir path =
+  match find_root path with
+  | Some (root, relpath) ->
+      let dst_dir' = Fpath.append dst_dir relpath in
+      prepare_lib dst_dir' path;
+      prepare_doc dst_dir' Fpath.(root / "doc" // relpath)
+  | None ->
+      Format.eprintf "Warning: Ignored path '%a'\n" Fpath.pp path;
+      ()
+
+let ocamlfind_query packages =
+  let cmd = Filename.quote_command "ocamlfind" ("query" :: "-r" :: packages) in
+  Process_util.lines_of_process cmd
+  |> (* Sort to ensure reproducibility and remove duplicates just in case. *)
+  List.sort_uniq String.compare
+  |> List.map Fpath.v
+
+let run out packages =
+  List.iter (prepare_package (Fpath.v out)) (ocamlfind_query packages)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -21,3 +21,37 @@ module Process_util = struct
         Format.eprintf "Command failed: %s\n" p;
         exit 1
 end
+
+module List_util = struct
+  (** Split a list on the first element that satisfy [p] starting from the end
+      of the list. Return [None] if no element matched. *)
+  let split_at_right p lst =
+    let rec loop p right = function
+      | [] -> None
+      | hd :: left when p hd -> Some (List.rev left, hd, right)
+      | hd :: left -> loop p (hd :: right) left
+    in
+    loop p [] (List.rev lst)
+end
+
+module Fs_util = struct
+  let dir_contents dir =
+    let contents = Sys.readdir (Fpath.to_string dir) in
+    (* Sort to ensure reproducibility (eg. order of log messages). *)
+    Array.sort String.compare contents;
+    contents |> Array.map (Fpath.( / ) dir) |> Array.to_list
+
+  let is_dir x = Sys.is_directory (Fpath.to_string x)
+
+  let dir_exists x =
+    let p = Fpath.to_string x in
+    Sys.file_exists p && Sys.is_directory p
+
+  let rec mkdir_rec dir =
+    let dir_s = Fpath.to_string dir in
+    if not (Sys.file_exists dir_s) then (
+      mkdir_rec (Fpath.parent dir);
+      Unix.mkdir dir_s 0o777 )
+end
+
+let path_of_segs segs = Fpath.v (String.concat Fpath.dir_sep segs)

--- a/test/dune_with_mld.t/run.t
+++ b/test/dune_with_mld.t/run.t
@@ -2,55 +2,34 @@ A basic test for working with Dune's _build/install.
 
   $ dune build -p test
 
-  $ find _build/install
-  _build/install
-  _build/install/default
-  _build/install/default/doc
-  _build/install/default/doc/test
-  _build/install/default/doc/test/odoc-pages
-  _build/install/default/doc/test/odoc-pages/test.mld
-  _build/install/default/lib
-  _build/install/default/lib/test
-  _build/install/default/lib/test/test.cmxa
-  _build/install/default/lib/test/test.cmti
-  _build/install/default/lib/test/test.ml
-  _build/install/default/lib/test/opam
-  _build/install/default/lib/test/test.cmx
-  _build/install/default/lib/test/test.a
-  _build/install/default/lib/test/test.cma
-  _build/install/default/lib/test/test.mli
-  _build/install/default/lib/test/META
-  _build/install/default/lib/test/test.cmi
-  _build/install/default/lib/test/test.cmxs
-  _build/install/default/lib/test/dune-package
-  _build/install/default/lib/test/test.cmt
+Prepare packages:
 
-Use paths found by findlib:
+  $ dune exec -- odocmkgen prepare-packages -o prep test
+  Copy '$TESTCASE_ROOT/_build/install/default/lib/test/test.cmi' -> 'prep/test/test.cmi'
+  Copy '$TESTCASE_ROOT/_build/install/default/lib/test/test.cmt' -> 'prep/test/test.cmt'
+  Copy '$TESTCASE_ROOT/_build/install/default/lib/test/test.cmti' -> 'prep/test/test.cmti'
+  Copy '$TESTCASE_ROOT/_build/install/default/doc/test/odoc-pages/test.mld' -> 'prep/test/test.mld'
 
-  $ P=$(dune exec -- ocamlfind query test)
-  $ echo "$P"
-  $TESTCASE_ROOT/_build/install/default/lib/test
+Build:
 
-  $ odocmkgen -- "$P" > Makefile
+  $ odocmkgen -- prep/* > Makefile
 
   $ make html
-  odocmkgen gen $TESTCASE_ROOT/_build/install/default/lib/test
-  Warning, couldn't find dep CamlinternalFormatBasics of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
-  Warning, couldn't find dep Stdlib of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
-  'odoc' 'compile' '--package' 'test' '$TESTCASE_ROOT/_build/install/default/doc/test/odoc-pages/test.mld' '-o' 'odocs/test/odoc-pages/page-test.odoc'
-  'odoc' 'compile' '--package' 'test' '$TESTCASE_ROOT/_build/install/default/lib/test/test.cmti' '-o' 'odocs/test/test.odoc'
-  'odoc' 'link' 'odocs/test/odoc-pages/page-test.odoc' '-o' 'odocls/test/odoc-pages/page-test.odocl' '-I' 'odocs/test/' '-I' 'odocs/test/odoc-pages/'
-  'odoc' 'link' 'odocs/test/test.odoc' '-o' 'odocls/test/test.odocl' '-I' 'odocs/test/' '-I' 'odocs/test/odoc-pages/'
+  odocmkgen gen prep/test
+  Warning, couldn't find dep CamlinternalFormatBasics of file prep/test/test.cmti
+  Warning, couldn't find dep Stdlib of file prep/test/test.cmti
+  'odoc' 'compile' '--package' 'test' 'prep/test/test.cmti' '-o' 'odocs/test/test.odoc'
+  'odoc' 'link' 'odocs/test/test.odoc' '-o' 'odocls/test/test.odocl' '-I' 'odocs/test/'
   'odocmkgen' 'generate' '--package' 'test'
   dir=test file=Test
-  dir=test file=test
   odoc support-files --output-dir html
   odoc html-generate odocls/test/test.odocl --output-dir html
-  odoc html-generate odocls/test/odoc-pages/page-test.odocl --output-dir html
 
   $ jq_scan_references() { jq -c '.. | .["`Reference"]? | select(.) | .[0]'; }
 
 Doesn't resolve but should:
 
-  $ odoc_print odocls/test/odoc-pages/page-test.odocl | jq_scan_references
-  {"`Resolved":{"`Value":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"Test"]}},"x"]}}
+  $ odoc_print odocls/test/page-test.odocl | jq_scan_references
+  odoc_print: PATH argument: no `odocls/test/page-test.odocl' file or directory
+  Usage: odoc_print [OPTION]... PATH
+  Try `odoc_print --help' for more information.


### PR DESCRIPTION
This phase 'prepare' a directory tree suitable for calling odocmkgen on it.
This abstracts specific details like the notion of "package" and the layout used to represent them from the main tool.

The goal is to define an input for odocmkgen that is both simpler and exposes every features of Odoc (especially parent-child).

For now it does nothing specific but in the future it'll do:
- Simplify the detection of mld pages (it's not complicated but very specific)
- Remove the notion of "package" from the main tool and greatly simplify it
- Allow to experiment a better API that'll work better for https://github.com/jonludlam/voodoo-prep (instead of https://github.com/jonludlam/odocmkgen/pull/11)