### PR TITLE
Take a single input path

### DIFF
--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -29,7 +29,7 @@ let compile_fragment all_infos info =
   let open Makefile in
   concat
     [
-      rule odoc_path
+      rule [ odoc_path ]
         ~fdeps:(Inputs.input_file info :: dep_odocs)
         [
           cmd "odoc" $ "compile" $ "--package" $ info.package $ "$<"

--- a/lib/gen.ml
+++ b/lib/gen.ml
@@ -1,5 +1,5 @@
-let run whitelist roots =
-  let inputs = Inputs.find_inputs ~whitelist roots in
+let run root =
+  let inputs = Inputs.find_inputs root in
   let oc = open_out "Makefile.gen" in
   let fmt = Format.formatter_of_out_channel oc in
   Fun.protect

--- a/lib/generate.ml
+++ b/lib/generate.ml
@@ -1,4 +1,5 @@
 open Listm
+open Util
 
 let output_dir = function `Html -> "html" | `Latex -> "latex" | `Man -> "man"
 
@@ -11,7 +12,7 @@ let make_target = function `Html -> "html" | `Latex -> "latex" | `Man -> "man"
 
 let mk_pkg target path =
   let files =
-    Inputs.find_files path >>= fun p ->
+    Fs_util.dir_contents_rec path >>= fun p ->
     if Fpath.has_ext ".odocl" p then [ p ] else []
   in
   List.map

--- a/lib/generate.ml
+++ b/lib/generate.ml
@@ -1,41 +1,48 @@
 open Listm
 
-let paths_of_package all_files package =
-  let all_paths =
-    all_files >>= fun file ->
-    match Fpath.(segs (normalize file)) with
-    | "odocls" :: pkg :: _ when pkg = package -> [Fpath.add_ext "odocl" file]
-    | _ -> []
+let output_dir = function `Html -> "html" | `Latex -> "latex" | `Man -> "man"
+
+let generate_command = function
+  | `Html -> "html-generate"
+  | `Latex -> "latex-generate"
+  | `Man -> "man-generate"
+
+let make_target = function `Html -> "html" | `Latex -> "latex" | `Man -> "man"
+
+let mk_pkg target path =
+  let files =
+    Inputs.find_files path >>= fun p ->
+    if Fpath.has_ext ".odocl" p then [ p ] else []
   in
-  setify all_paths
+  List.map
+    (fun f ->
+      let outputs = List.map Fpath.v (Odoc.generate_targets f target) in
+      Makefile.(
+        concat
+          [
+            phony_rule (make_target target) ~fdeps:outputs [];
+            rule outputs ~fdeps:[ f ]
+              [
+                cmd "odoc" $ generate_command target $ "--output-dir"
+                $ output_dir target $ "$<";
+              ];
+          ]))
+    files
+  |> Makefile.concat
 
-let run path package =
-  let package_makefile = Printf.sprintf "Makefile.%s.generate" package in
+let prelude =
+  let open Makefile in
+  let odoc_css = Fpath.v "html/odoc.css" in
+  concat
+    [
+      phony_rule "default" ~deps:[ "html" ] [];
+      phony_rule "html" ~fdeps:[ odoc_css ] [];
+      rule [ odoc_css ] [ cmd "odoc" $ "support-files" $ "--output-dir" $ "html" ];
+    ]
 
-  let all_files = Inputs.find_files path >>= fun p ->
-    let base, ext = Fpath.split_ext p in
-    if ext = ".odocl" then [ base ] else []
+let run paths =
+  let makefile =
+    let mk target = Makefile.concat (List.map (mk_pkg target) paths) in
+    Makefile.concat [ prelude; mk `Html; mk `Latex; mk `Man ]
   in
-
-  let pkg_files = paths_of_package all_files package in
-
-  let oc = open_out package_makefile in
-
-  let mk format =
-    List.iter
-      (fun f ->
-        let str_format = match format with | `Html -> "html" | `Latex -> "latex" | `Man -> "man" in
-        let targets = Odoc.generate_targets f format in
-        let str = Format.asprintf "%s &: %a\n\todoc %s-generate %a --output-dir %s\n" (String.concat " " targets) Fpath.pp f str_format Fpath.pp f str_format in
-        Printf.fprintf oc "%s" str;
-        let str = Format.asprintf "%s : %s\n" str_format (String.concat " " targets) in
-        Printf.fprintf oc "%s" str
-        ) pkg_files;
-  in
-
-  mk `Html;
-  mk `Latex;
-  mk `Man;
-
-  close_out oc
-
+  Format.printf "%a\n" Makefile.pp makefile

--- a/lib/link.ml
+++ b/lib/link.ml
@@ -80,17 +80,7 @@ let gen (inputs : Inputs.t list) =
   StringMap.fold
     (fun package inputs acc ->
       let package_deps = package :: StringMap.find package package_deps in
-      let output_files = List.map Inputs.link_target inputs in
-      let pkg_makefile =
-        Fpath.v (Format.asprintf "Makefile.%s.generate" package)
-      in
       let open Makefile in
       concat
-        [
-          acc;
-          concat (List.map (gen_input ~packages ~package_deps) inputs);
-          rule [ pkg_makefile ] ~fdeps:output_files
-            [ cmd "odocmkgen" $ "generate" $ "--package" $ package ];
-          include_ pkg_makefile;
-        ])
+        [ acc; concat (List.map (gen_input ~packages ~package_deps) inputs) ])
     packages (Makefile.concat [])

--- a/lib/link.ml
+++ b/lib/link.ml
@@ -32,7 +32,7 @@ let gen_input ~packages ~package_deps inp =
   in
   concat
     [
-      rule output_file ~fdeps:[ input_file ] ~oo_deps:compile_pkg_deps
+      rule [ output_file ] ~fdeps:[ input_file ] ~oo_deps:compile_pkg_deps
         [ cmd "odoc" $ "link" $ "$<" $ "-o" $ "$@" $$ inc_args ];
       phony_rule "link" ~fdeps:[ output_file ] [];
     ]
@@ -89,7 +89,7 @@ let gen (inputs : Inputs.t list) =
         [
           acc;
           concat (List.map (gen_input ~packages ~package_deps) inputs);
-          rule pkg_makefile ~fdeps:output_files
+          rule [ pkg_makefile ] ~fdeps:output_files
             [ cmd "odocmkgen" $ "generate" $ "--package" $ package ];
           include_ pkg_makefile;
         ])

--- a/lib/makefile.mli
+++ b/lib/makefile.mli
@@ -8,7 +8,7 @@ type cmd
 val concat : t list -> t
 
 val rule :
-  Fpath.t ->
+  Fpath.t list ->
   ?fdeps:Fpath.t list ->
   ?deps:string list ->
   ?oo_deps:string list ->

--- a/lib/prepare_packages.ml
+++ b/lib/prepare_packages.ml
@@ -1,0 +1,60 @@
+(** This is a separate tool and doesn't interfere with the rest of odocmkgen.
+    It is linked into the same binary for convenience. *)
+
+open Util
+
+let copy_file ~dst ~src =
+  Format.eprintf "Copy '%a' -> '%a'\n" Fpath.pp src Fpath.pp dst;
+  ignore
+    (Process_util.lines_of_process
+       (Filename.quote_command "cp"
+          [ Fpath.to_string src; Fpath.to_string dst ]))
+
+(** Copy files from [src_dir] that satisfy [p] to [dst_dir].
+    Create [dst_dir] if needed. *)
+let copy_files_from src_dir ~dst_dir p =
+  match Fs_util.dir_contents src_dir with
+  | exception Sys_error _ -> ()
+  | [] -> ()
+  | srcs ->
+      Fs_util.mkdir_rec dst_dir;
+      List.iter
+        (fun src ->
+          if p src then
+            let dst = Fpath.append dst_dir (Fpath.base src) in
+            copy_file ~dst ~src)
+        srcs
+
+let prepare_doc dst_dir src =
+  (* TODO: Common files in [src]: Readme, changes, license (.md, .org, no ext) *)
+  (* TODO: Other files: example files (.ml), manuals and markdown doc *)
+  copy_files_from Fpath.(src / "odoc-pages") ~dst_dir (Fpath.has_ext ".mld")
+
+let prepare_lib dst_dir src =
+  copy_files_from src ~dst_dir (Fpath.mem_ext [ ".cmti"; ".cmt"; ".cmi" ])
+
+(** Expect paths containing a 'lib' segment, other paths are ignored. *)
+let find_root path =
+  match List_util.split_at_right (( = ) "lib") (Fpath.segs path) with
+  | Some (root, _, relpath) -> Some (path_of_segs root, path_of_segs relpath)
+  | None -> None
+
+let prepare_package dst_dir path =
+  match find_root path with
+  | Some (root, relpath) ->
+      let dst_dir' = Fpath.append dst_dir relpath in
+      prepare_lib dst_dir' path;
+      prepare_doc dst_dir' Fpath.(root / "doc" // relpath)
+  | None ->
+      Format.eprintf "Warning: Ignored path '%a'\n" Fpath.pp path;
+      ()
+
+let ocamlfind_query packages =
+  let cmd = Filename.quote_command "ocamlfind" ("query" :: "-r" :: packages) in
+  Process_util.lines_of_process cmd
+  |> (* Sort to ensure reproducibility and remove duplicates just in case. *)
+  List.sort_uniq String.compare
+  |> List.map Fpath.v
+
+let run out packages =
+  List.iter (prepare_package (Fpath.v out)) (ocamlfind_query packages)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -43,6 +43,17 @@ module Fs_util = struct
 
   let is_dir x = Sys.is_directory (Fpath.to_string x)
 
+let dir_contents_rec dir =
+  let rec loop acc dir =
+    Sys.readdir (Fpath.to_string dir)
+    |> Array.fold_left
+         (fun acc fname ->
+           let p = Fpath.( / ) dir fname in
+           if is_dir p then loop acc p else p :: acc)
+         acc
+  in
+  List.sort Fpath.compare (loop [] dir)
+
   let dir_exists x =
     let p = Fpath.to_string x in
     Sys.file_exists p && Sys.is_directory p

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -21,3 +21,37 @@ module Process_util = struct
         Format.eprintf "Command failed: %s\n" p;
         exit 1
 end
+
+module List_util = struct
+  (** Split a list on the first element that satisfy [p] starting from the end
+      of the list. Return [None] if no element matched. *)
+  let split_at_right p lst =
+    let rec loop p right = function
+      | [] -> None
+      | hd :: left when p hd -> Some (List.rev left, hd, right)
+      | hd :: left -> loop p (hd :: right) left
+    in
+    loop p [] (List.rev lst)
+end
+
+module Fs_util = struct
+  let dir_contents dir =
+    let contents = Sys.readdir (Fpath.to_string dir) in
+    (* Sort to ensure reproducibility (eg. order of log messages). *)
+    Array.sort String.compare contents;
+    contents |> Array.map (Fpath.( / ) dir) |> Array.to_list
+
+  let is_dir x = Sys.is_directory (Fpath.to_string x)
+
+  let dir_exists x =
+    let p = Fpath.to_string x in
+    Sys.file_exists p && Sys.is_directory p
+
+  let rec mkdir_rec dir =
+    let dir_s = Fpath.to_string dir in
+    if not (Sys.file_exists dir_s) then (
+      mkdir_rec (Fpath.parent dir);
+      Unix.mkdir dir_s 0o777 )
+end
+
+let path_of_segs segs = Fpath.v (String.concat Fpath.dir_sep segs)

--- a/odocmkgen.ml
+++ b/odocmkgen.ml
@@ -29,63 +29,40 @@ let read_doc_dir () =
   let dir = read_lib_dir () in
   Fpath.(to_string (fst (Fpath.split_base (v dir)) / "doc"))
 
-module Default = struct
-    let default whitelist dirs =
-      let pp_whitelist fmt = function
-        | [] -> ()
-        | wl -> Format.fprintf fmt " -w %s" (String.concat "," wl)
-      in
-      let pp_dirs fmt l =
-        List.iter (fun lib -> Format.fprintf fmt " %s" lib) l
-      in
-      Format.printf {|
-default: link
-.PHONY: compile link clean html latex man
-compile: odocs
-link: compile odocls
-Makefile.gen : Makefile
-	odocmkgen gen%a%a
-odocs:
-	mkdir odocs
-odocls:
-	mkdir odocls
-clean:
-	rm -rf odocs odocls Makefile.gen
-ifneq ($(MAKECMDGOALS),clean)
--include Makefile.gen
-endif
-|} pp_whitelist whitelist pp_dirs dirs
+module Gen = struct
+  let prelude =
+    let open Makefile in
+    concat
+      [
+        phony_rule "default" ~deps:[ "link" ] [];
+        phony_rule "compile" ~oo_deps:[ "odocs" ] [];
+        phony_rule "link" ~deps:[ "compile" ] ~oo_deps:[ "odocls" ] [];
+        phony_rule "clean" [ cmd "rm" $ "-r" $ "odocs" $ "odocls" ];
+        rule [ Fpath.v "odocs" ] [ cmd "mkdir" $ "odocs" ];
+        rule [ Fpath.v "odocls" ] [ cmd "mkdir" $ "odocls" ];
+      ]
+
+  let run whitelist roots =
+    let inputs = Inputs.find_inputs ~whitelist roots in
+    let makefile =
+      let open Makefile in
+      concat [ prelude; Compile.gen inputs; Link.gen inputs ]
+    in
+    Format.printf "%a\n" Makefile.pp makefile
 
   let whitelist =
-    Arg.(value & opt (list string) [] & info ["w"; "whitelist"])
+    Arg.(value & opt (list string) [] & info [ "w"; "whitelist" ])
 
   let dirs =
     let doc =
-      "Path to libraries. They can be found by querying $(b,ocamlfind query -r my_package)."
+      "Path to libraries. They can be found by querying $(b,ocamlfind query -r \
+       my_package)."
     in
-    (* [some string] and not [some dir] because we don't need it to exist yet. *)
-    Arg.(value & pos_all string [] & info [] ~doc ~docv:"DIR")
-
-  let cmd =
-    Term.(const default $ whitelist $ dirs)
-
-  let info =
-    Term.info ~version:"%%VERSION%%" "odocmkgen"
-end
-
-module Gen = struct
-
-  let whitelist =
-    Arg.(value & opt (list string) [] & info ["w"; "whitelist"])
-
-  let dirs =
-    let doc = "Path to libraries." in
     Arg.(value & pos_all conv_fpath_dir [] & info [] ~doc ~docv:"DIR")
 
-  let cmd = Term.(const Gen.run $ whitelist $ dirs)
+  let cmd = Term.(const run $ whitelist $ dirs)
 
-  let info =
-    Term.info "gen" ~doc:"Produce a makefile for building the documentation."
+  let info = Term.info ~version:"%%VERSION%%" "odocmkgen"
 end
 
 module Generate = struct
@@ -145,5 +122,5 @@ let _ =
       OpamDeps.(cmd, info);
       PreparePackages.(cmd, info);
     ]
-  and default_cmd = Default.(cmd, info) in
+  and default_cmd = Gen.(cmd, info) in
   Term.exit (Term.eval_choice default_cmd cmds)

--- a/odocmkgen.ml
+++ b/odocmkgen.ml
@@ -14,7 +14,20 @@ let conv_compose ?docv parse to_string c =
   and print fmt t = conv_printer c fmt (to_string t) in
   conv ~docv (parse, print)
 
-let fpath_dir = conv_compose Fpath.of_string Fpath.to_string Arg.dir
+(** Like [Cmdliner.Arg.dir] but return a [Fpath.t] *)
+let conv_fpath_dir = conv_compose Fpath.of_string Fpath.to_string Arg.dir
+
+(* Just to find the location of all relevant ocaml cmt/cmti/cmis *)
+let read_lib_dir () =
+  match Util.Process_util.lines_of_process "ocamlfind printconf path" with
+  | [ base_dir ] -> base_dir
+  | _ ->
+      Format.eprintf "Failed to find ocaml lib path";
+      exit 1
+
+let read_doc_dir () =
+  let dir = read_lib_dir () in
+  Fpath.(to_string (fst (Fpath.split_base (v dir)) / "doc"))
 
 module Default = struct
     let default whitelist dirs =
@@ -26,22 +39,18 @@ module Default = struct
         List.iter (fun lib -> Format.fprintf fmt " %s" lib) l
       in
       Format.printf {|
-default: generate
-.PHONY: compile link generate clean html latex man
+default: link
+.PHONY: compile link clean html latex man
 compile: odocs
 link: compile odocls
 Makefile.gen : Makefile
 	odocmkgen gen%a%a
-generate: link
 odocs:
 	mkdir odocs
 odocls:
 	mkdir odocls
 clean:
-	rm -rf odocs odocls html latex man Makefile.*link Makefile.gen Makefile.*generate
-html: html/odoc.css
-html/odoc.css:
-	odoc support-files --output-dir html
+	rm -rf odocs odocls Makefile.gen
 ifneq ($(MAKECMDGOALS),clean)
 -include Makefile.gen
 endif
@@ -71,7 +80,7 @@ module Gen = struct
 
   let dirs =
     let doc = "Path to libraries." in
-    Arg.(value & pos_all fpath_dir [] & info [] ~doc ~docv:"DIR")
+    Arg.(value & pos_all conv_fpath_dir [] & info [] ~doc ~docv:"DIR")
 
   let cmd = Term.(const Gen.run $ whitelist $ dirs)
 
@@ -80,18 +89,15 @@ module Gen = struct
 end
 
 module Generate = struct
-  let generate package =
-    Generate.run (Fpath.v "odocls") package
+  let paths =
+    let doc = "Paths to packages of .odocl files." in
+    Arg.(non_empty & pos_all conv_fpath_dir [] & info [] ~docv:"PACKAGES" ~doc)
 
-  let package =
-    let doc = "Select the package to examine" in
-    Arg.(required & opt (some string) None & info ["p"; "package"]
-            ~docv:"PKG" ~doc)
-    
-  let cmd = Term.(const generate $ package)
+  let cmd = Term.(const Generate.run $ paths)
 
-  let info = Term.info "generate" ~doc:"Produce a makefile for generating outputs from odoc files"
-  
+  let info =
+    Term.info "generate"
+      ~doc:"Produce a makefile for generating outputs from odoc files"
 end
 
 module OpamDeps = struct

--- a/odocmkgen.ml
+++ b/odocmkgen.ml
@@ -42,27 +42,24 @@ module Gen = struct
         rule [ Fpath.v "odocls" ] [ cmd "mkdir" $ "odocls" ];
       ]
 
-  let run whitelist roots =
-    let inputs = Inputs.find_inputs ~whitelist roots in
+  let run dir =
+    let inputs = Inputs.find_inputs dir in
     let makefile =
       let open Makefile in
       concat [ prelude; Compile.gen inputs; Link.gen inputs ]
     in
     Format.printf "%a\n" Makefile.pp makefile
 
-  let whitelist =
-    Arg.(value & opt (list string) [] & info [ "w"; "whitelist" ])
-
-  let dirs =
+  let dir =
     let doc =
-      "Path to libraries. They can be found by querying $(b,ocamlfind query -r \
-       my_package)."
+      "Input directory tree. This tree can be prepared with the \
+       $(b,prepare-package) command."
     in
-    Arg.(value & pos_all conv_fpath_dir [] & info [] ~doc ~docv:"DIR")
+    Arg.(required & pos 0 (some conv_fpath_dir) None & info [] ~doc ~docv:"DIR")
 
-  let cmd = Term.(const run $ whitelist $ dirs)
+  let cmd = Term.(const run $ dir)
 
-  let info = Term.info ~version:"%%VERSION%%" "odocmkgen"
+  let info = Term.info ~version:"%%VERSION%%" "gen"
 end
 
 module Generate = struct

--- a/test/dune_with_mld.t/run.t
+++ b/test/dune_with_mld.t/run.t
@@ -10,20 +10,20 @@ Prepare packages:
   Copy '$TESTCASE_ROOT/_build/install/default/lib/test/test.cmti' -> 'prep/test/test.cmti'
   Copy '$TESTCASE_ROOT/_build/install/default/doc/test/odoc-pages/test.mld' -> 'prep/test/test.mld'
 
-Build:
+Generate the Makefile:
 
   $ odocmkgen -- prep/* > Makefile
 
-  $ make html
+Build:
+
+  $ make
   odocmkgen gen prep/test
   Warning, couldn't find dep CamlinternalFormatBasics of file prep/test/test.cmti
   Warning, couldn't find dep Stdlib of file prep/test/test.cmti
+  mkdir odocs
   'odoc' 'compile' '--package' 'test' 'prep/test/test.cmti' '-o' 'odocs/test/test.odoc'
+  mkdir odocls
   'odoc' 'link' 'odocs/test/test.odoc' '-o' 'odocls/test/test.odocl' '-I' 'odocs/test/'
-  'odocmkgen' 'generate' '--package' 'test'
-  dir=test file=Test
-  odoc support-files --output-dir html
-  odoc html-generate odocls/test/test.odocl --output-dir html
 
   $ jq_scan_references() { jq -c '.. | .["`Reference"]? | select(.) | .[0]'; }
 

--- a/test/dune_with_mld.t/run.t
+++ b/test/dune_with_mld.t/run.t
@@ -12,7 +12,7 @@ Prepare packages:
 
 Generate the Makefile:
 
-  $ odocmkgen -- prep/* > Makefile
+  $ odocmkgen gen prep > Makefile
   Warning, couldn't find dep CamlinternalFormatBasics of file prep/test/test.cmti
   Warning, couldn't find dep Stdlib of file prep/test/test.cmti
 
@@ -21,7 +21,9 @@ Build:
   $ make
   'mkdir' 'odocs'
   'odoc' 'compile' '--package' 'test' 'prep/test/test.cmti' '-o' 'odocs/test/test.odoc'
+  'odoc' 'compile' '--package' 'test' 'prep/test/test.mld' '-o' 'odocs/test/page-test.odoc'
   'mkdir' 'odocls'
+  'odoc' 'link' 'odocs/test/page-test.odoc' '-o' 'odocls/test/page-test.odocl' '-I' 'odocs/test/'
   'odoc' 'link' 'odocs/test/test.odoc' '-o' 'odocls/test/test.odocl' '-I' 'odocs/test/'
 
   $ jq_scan_references() { jq -c '.. | .["`Reference"]? | select(.) | .[0]'; }
@@ -29,15 +31,15 @@ Build:
 Doesn't resolve but should:
 
   $ odoc_print odocls/test/page-test.odocl | jq_scan_references
-  odoc_print: PATH argument: no `odocls/test/page-test.odocl' file or directory
-  Usage: odoc_print [OPTION]... PATH
-  Try `odoc_print --help' for more information.
+  {"`Resolved":{"`Value":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"Test"]}},"x"]}}
 
 Finally, render:
 
   $ odocmkgen generate odocls > Makefile.gen
+  dir=test file=test
   dir=test file=Test
 
   $ make -f Makefile.gen html
   'odoc' 'support-files' '--output-dir' 'html'
+  'odoc' 'html-generate' '--output-dir' 'html' 'odocls/test/page-test.odocl'
   'odoc' 'html-generate' '--output-dir' 'html' 'odocls/test/test.odocl'

--- a/test/dune_with_mld.t/run.t
+++ b/test/dune_with_mld.t/run.t
@@ -13,16 +13,15 @@ Prepare packages:
 Generate the Makefile:
 
   $ odocmkgen -- prep/* > Makefile
+  Warning, couldn't find dep CamlinternalFormatBasics of file prep/test/test.cmti
+  Warning, couldn't find dep Stdlib of file prep/test/test.cmti
 
 Build:
 
   $ make
-  odocmkgen gen prep/test
-  Warning, couldn't find dep CamlinternalFormatBasics of file prep/test/test.cmti
-  Warning, couldn't find dep Stdlib of file prep/test/test.cmti
-  mkdir odocs
+  'mkdir' 'odocs'
   'odoc' 'compile' '--package' 'test' 'prep/test/test.cmti' '-o' 'odocs/test/test.odoc'
-  mkdir odocls
+  'mkdir' 'odocls'
   'odoc' 'link' 'odocs/test/test.odoc' '-o' 'odocls/test/test.odocl' '-I' 'odocs/test/'
 
   $ jq_scan_references() { jq -c '.. | .["`Reference"]? | select(.) | .[0]'; }
@@ -33,3 +32,12 @@ Doesn't resolve but should:
   odoc_print: PATH argument: no `odocls/test/page-test.odocl' file or directory
   Usage: odoc_print [OPTION]... PATH
   Try `odoc_print --help' for more information.
+
+Finally, render:
+
+  $ odocmkgen generate odocls > Makefile.gen
+  dir=test file=Test
+
+  $ make -f Makefile.gen html
+  'odoc' 'support-files' '--output-dir' 'html'
+  'odoc' 'html-generate' '--output-dir' 'html' 'odocls/test/test.odocl'

--- a/test/dune_with_mld.t/run.t
+++ b/test/dune_with_mld.t/run.t
@@ -2,55 +2,34 @@ A basic test for working with Dune's _build/install.
 
   $ dune build -p test
 
-  $ find _build/install
-  _build/install
-  _build/install/default
-  _build/install/default/doc
-  _build/install/default/doc/test
-  _build/install/default/doc/test/odoc-pages
-  _build/install/default/doc/test/odoc-pages/test.mld
-  _build/install/default/lib
-  _build/install/default/lib/test
-  _build/install/default/lib/test/test.cmxa
-  _build/install/default/lib/test/test.cmti
-  _build/install/default/lib/test/test.ml
-  _build/install/default/lib/test/opam
-  _build/install/default/lib/test/test.cmx
-  _build/install/default/lib/test/test.a
-  _build/install/default/lib/test/test.cma
-  _build/install/default/lib/test/test.mli
-  _build/install/default/lib/test/META
-  _build/install/default/lib/test/test.cmi
-  _build/install/default/lib/test/test.cmxs
-  _build/install/default/lib/test/dune-package
-  _build/install/default/lib/test/test.cmt
+Prepare packages:
 
-Use paths found by findlib:
+  $ dune exec -- odocmkgen prepare-packages -o prep test
+  Copy '$TESTCASE_ROOT/_build/install/default/lib/test/test.cmi' -> 'prep/test/test.cmi'
+  Copy '$TESTCASE_ROOT/_build/install/default/lib/test/test.cmt' -> 'prep/test/test.cmt'
+  Copy '$TESTCASE_ROOT/_build/install/default/lib/test/test.cmti' -> 'prep/test/test.cmti'
+  Copy '$TESTCASE_ROOT/_build/install/default/doc/test/odoc-pages/test.mld' -> 'prep/test/test.mld'
 
-  $ P=$(dune exec -- ocamlfind query test)
-  $ echo "$P"
-  $TESTCASE_ROOT/_build/install/default/lib/test
+Build:
 
-  $ odocmkgen -- "$P" > Makefile
+  $ odocmkgen -- prep/* > Makefile
 
   $ make html
-  odocmkgen gen $TESTCASE_ROOT/_build/install/default/lib/test
-  Warning, couldn't find dep CamlinternalFormatBasics of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
-  Warning, couldn't find dep Stdlib of file $TESTCASE_ROOT/_build/install/default/lib/test/test.cmti
-  'odoc' 'compile' '--package' 'test' '$TESTCASE_ROOT/_build/install/default/doc/test/odoc-pages/test.mld' '-o' 'odocs/test/odoc-pages/page-test.odoc'
-  'odoc' 'compile' '--package' 'test' '$TESTCASE_ROOT/_build/install/default/lib/test/test.cmti' '-o' 'odocs/test/test.odoc'
-  'odoc' 'link' 'odocs/test/odoc-pages/page-test.odoc' '-o' 'odocls/test/odoc-pages/page-test.odocl' '-I' 'odocs/test/' '-I' 'odocs/test/odoc-pages/'
-  'odoc' 'link' 'odocs/test/test.odoc' '-o' 'odocls/test/test.odocl' '-I' 'odocs/test/' '-I' 'odocs/test/odoc-pages/'
+  odocmkgen gen prep/test
+  Warning, couldn't find dep CamlinternalFormatBasics of file prep/test/test.cmti
+  Warning, couldn't find dep Stdlib of file prep/test/test.cmti
+  'odoc' 'compile' '--package' 'test' 'prep/test/test.cmti' '-o' 'odocs/test/test.odoc'
+  'odoc' 'link' 'odocs/test/test.odoc' '-o' 'odocls/test/test.odocl' '-I' 'odocs/test/'
   'odocmkgen' 'generate' '--package' 'test'
   dir=test file=Test
-  dir=test file=test
   odoc support-files --output-dir html
   odoc html-generate odocls/test/test.odocl --output-dir html
-  odoc html-generate odocls/test/odoc-pages/page-test.odocl --output-dir html
 
   $ jq_scan_references() { jq -c '.. | .["`Reference"]? | select(.) | .[0]'; }
 
 Doesn't resolve but should:
 
-  $ odoc_print odocls/test/odoc-pages/page-test.odocl | jq_scan_references
-  {"`Resolved":{"`Value":[{"`Identifier":{"`Root":[{"`RootPage":"test"},"Test"]}},"x"]}}
+  $ odoc_print odocls/test/page-test.odocl | jq_scan_references
+  odoc_print: PATH argument: no `odocls/test/page-test.odocl' file or directory
+  Usage: odoc_print [OPTION]... PATH
+  Try `odoc_print --help' for more information.

--- a/test/example.t/run.t
+++ b/test/example.t/run.t
@@ -3,17 +3,16 @@ The driver works on compiled files:
   $ ocamlc -I b -I a b/b.mli b/b.ml a/a.mli a/a.ml
 
   $ odocmkgen -- a b > Makefile
-
-  $ make
-  odocmkgen gen a b
   Warning, couldn't find dep CamlinternalFormatBasics of file a/a.cmi
   Warning, couldn't find dep Stdlib of file a/a.cmi
   Warning, couldn't find dep CamlinternalFormatBasics of file b/b.cmi
   Warning, couldn't find dep Stdlib of file b/b.cmi
-  mkdir odocs
+
+  $ make
+  'mkdir' 'odocs'
   'odoc' 'compile' '--package' 'a' 'a/a.cmi' '-o' 'odocs/a/a.odoc'
   'odoc' 'compile' '--package' 'b' 'b/b.cmi' '-o' 'odocs/b/b.odoc'
-  mkdir odocls
+  'mkdir' 'odocls'
   'odoc' 'link' 'odocs/a/a.odoc' '-o' 'odocls/a/a.odocl' '-I' 'odocs/a/'
   'odoc' 'link' 'odocs/b/b.odoc' '-o' 'odocls/b/b.odocl' '-I' 'odocs/b/'
 

--- a/test/example.t/run.t
+++ b/test/example.t/run.t
@@ -4,26 +4,55 @@ The driver works on compiled files:
 
   $ odocmkgen -- a b > Makefile
 
-  $ make html
+  $ make
   odocmkgen gen a b
   Warning, couldn't find dep CamlinternalFormatBasics of file a/a.cmi
   Warning, couldn't find dep Stdlib of file a/a.cmi
   Warning, couldn't find dep CamlinternalFormatBasics of file b/b.cmi
   Warning, couldn't find dep Stdlib of file b/b.cmi
-  'odoc' 'compile' '--package' 'b' 'b/b.cmi' '-o' 'odocs/b/b.odoc'
-  'odoc' 'link' 'odocs/b/b.odoc' '-o' 'odocls/b/b.odocl' '-I' 'odocs/b/'
-  'odocmkgen' 'generate' '--package' 'b'
-  dir=b file=B
+  mkdir odocs
   'odoc' 'compile' '--package' 'a' 'a/a.cmi' '-o' 'odocs/a/a.odoc'
+  'odoc' 'compile' '--package' 'b' 'b/b.cmi' '-o' 'odocs/b/b.odoc'
+  mkdir odocls
   'odoc' 'link' 'odocs/a/a.odoc' '-o' 'odocls/a/a.odocl' '-I' 'odocs/a/'
-  'odocmkgen' 'generate' '--package' 'a'
-  dir=a file=A
-  odoc support-files --output-dir html
-  odoc html-generate odocls/a/a.odocl --output-dir html
-  odoc html-generate odocls/b/b.odocl --output-dir html
+  'odoc' 'link' 'odocs/b/b.odoc' '-o' 'odocls/b/b.odocl' '-I' 'odocs/b/'
 
-  $ ls Makefile*
-  Makefile
-  Makefile.a.generate
-  Makefile.b.generate
-  Makefile.gen
+  $ odocmkgen generate odocls/* > Makefile.generate
+  dir=a file=A
+  dir=b file=B
+
+  $ make -f Makefile.generate html
+  'odoc' 'support-files' '--output-dir' 'html'
+  'odoc' 'html-generate' '--output-dir' 'html' 'odocls/a/a.odocl'
+  'odoc' 'html-generate' '--output-dir' 'html' 'odocls/b/b.odocl'
+
+  $ make -f Makefile.generate latex
+  'odoc' 'latex-generate' '--output-dir' 'latex' 'odocls/a/a.odocl'
+  dir=a file=A
+  'odoc' 'latex-generate' '--output-dir' 'latex' 'odocls/b/b.odocl'
+  dir=b file=B
+
+  $ make -f Makefile.generate man
+  'odoc' 'man-generate' '--output-dir' 'man' 'odocls/a/a.odocl'
+  'odoc' 'man-generate' '--output-dir' 'man' 'odocls/b/b.odocl'
+
+  $ find html latex man | sort
+  html
+  html/a
+  html/a/A
+  html/a/A/index.html
+  html/b
+  html/b/B
+  html/b/B/index.html
+  html/highlight.pack.js
+  html/odoc.css
+  latex
+  latex/a
+  latex/a/A.tex
+  latex/b
+  latex/b/B.tex
+  man
+  man/a
+  man/a/A.3o
+  man/b
+  man/b/B.3o

--- a/test/example.t/run.t
+++ b/test/example.t/run.t
@@ -2,11 +2,11 @@ The driver works on compiled files:
 
   $ ocamlc -I b -I a b/b.mli b/b.ml a/a.mli a/a.ml
 
-  $ odocmkgen -- a b > Makefile
-  Warning, couldn't find dep CamlinternalFormatBasics of file a/a.cmi
-  Warning, couldn't find dep Stdlib of file a/a.cmi
-  Warning, couldn't find dep CamlinternalFormatBasics of file b/b.cmi
-  Warning, couldn't find dep Stdlib of file b/b.cmi
+  $ odocmkgen gen . > Makefile
+  Warning, couldn't find dep CamlinternalFormatBasics of file ./b/b.cmi
+  Warning, couldn't find dep Stdlib of file ./b/b.cmi
+  Warning, couldn't find dep CamlinternalFormatBasics of file ./a/a.cmi
+  Warning, couldn't find dep Stdlib of file ./a/a.cmi
 
   $ make
   'mkdir' 'odocs'


### PR DESCRIPTION
(on top of #13 and #14)

After #14, taking several paths doesn't make sense anymore. The whitelist argument is also removed because superseded by the prep step.
